### PR TITLE
updating make build to default to openmpi

### DIFF
--- a/BuildWithMake/MakeHelpers/mpich.x64_linux.mk
+++ b/BuildWithMake/MakeHelpers/mpich.x64_linux.mk
@@ -1,0 +1,7 @@
+MPI_NAME    = mpich
+MPI_INCDIR  = -I $(MPI_TOP)/include -L $(MPI_TOP)/lib
+MPI_LIBS    = $(shell mpif90 -link_info | awk '{print substr($0, index($0,$2))}')
+MPI_SO_PATH = $(shell which mpiexec)/..
+MPIEXEC_PATH  = $(dir $(shell which mpiexec))
+MPIEXEC       = mpiexec
+

--- a/BuildWithMake/MakeHelpers/mpich.x64_linux.mk
+++ b/BuildWithMake/MakeHelpers/mpich.x64_linux.mk
@@ -1,7 +1,7 @@
 MPI_NAME    = mpich
-MPI_INCDIR  = -I $(MPI_TOP)/include -L $(MPI_TOP)/lib
-MPI_LIBS    = $(shell mpif90 -link_info | awk '{print substr($0, index($0,$2))}')
-MPI_SO_PATH = $(shell which mpiexec)/..
-MPIEXEC_PATH  = $(dir $(shell which mpiexec))
+MPI_INCDIR  = $(wordlist 2,99,$(shell mpif90 -link_info))
+MPI_LIBS    = $(wordlist 2,99,$(shell mpif90 -link_info))
+MPI_SO_PATH = 
+MPIEXEC_PATH  = 
 MPIEXEC       = mpiexec
 

--- a/BuildWithMake/MakeHelpers/mpich2.usr.local.x64_linux.mk
+++ b/BuildWithMake/MakeHelpers/mpich2.usr.local.x64_linux.mk
@@ -1,9 +1,0 @@
-ifeq ($(CLUSTER), x64_linux)
-    MPI_NAME    = mpich
-    MPI_TOP     =  /usr/local
-    MPI_INCDIR  = -I$(MPI_TOP)/include -L$(MPI_TOP)/lib
-    MPI_LIBS    = -lmpichf90 -lmpich -lopa -lmpl -lrt -lpthread
-    MPI_SO_PATH = $(MPI_TOP)/mpich2/lib
-    MPIEXEC_PATH  = /usr/bin
-    MPIEXEC       = mpiexec
-endif

--- a/BuildWithMake/MakeHelpers/mpich2.usr.x64_linux.mk
+++ b/BuildWithMake/MakeHelpers/mpich2.usr.x64_linux.mk
@@ -1,9 +1,0 @@
-ifeq ($(CLUSTER), x64_linux)
-    MPI_NAME    = mpich
-    MPI_TOP     =  /usr/lib/mpich
-    MPI_INCDIR  = -I $(MPI_TOP)/include -L $(MPI_TOP)/lib
-    MPI_LIBS    = -lmpichf90 -lmpich -lopa -lmpl -lrt -lpthread
-    MPI_SO_PATH = $(MPI_TOP)/lib
-    MPIEXEC_PATH  = /usr/bin
-    MPIEXEC       = mpiexec
-endif

--- a/BuildWithMake/MakeHelpers/openmpi.x64_linux.mk
+++ b/BuildWithMake/MakeHelpers/openmpi.x64_linux.mk
@@ -1,0 +1,6 @@
+MPI_NAME    = openmpi
+MPI_INCDIR  = $(shell mpif90 --showme:compile)
+MPI_LIBS    = $(shell mpif90 --showme:link)
+MPI_SO_PATH = $(shell which mpiexec)/../..
+MPIEXEC_PATH  = $(dir $(shell which mpiexec))
+MPIEXEC       = mpiexec

--- a/BuildWithMake/include.mk
+++ b/BuildWithMake/include.mk
@@ -153,6 +153,8 @@ FLOWSOLVER_VERSION_USE_VTK_ACTIVATE = 1
 # -----------------------------------------------------
 
 MAKE_WITH_MPI = 1
+MAKE_WITH_OPENMPI = 1
+MAKE_WITH_MPICH = 0
 
 # -----------------------------------------------------
 # Build only the 3D Solver
@@ -215,20 +217,6 @@ else
 -include $(TOP)/site_overrides.mk
 endif
 
-# by default don't build most third party
-# if we are only building the flow solver
-ifeq ($(EXCLUDE_ALL_BUT_THREEDSOLVER), 1)
-    ifeq ($(FLOWSOLVER_VERSION_USE_VTK_ACTIVATE), 0)
-        MAKE_WITH_VTK = 0
-    endif
-
-    MAKE_WITH_ITK = 0
-    MAKE_WITH_VMTK = 0
-    MAKE_WITH_TETGEN = 0
-    MAKE_WITH_SPARSE = 0
-    MAKE_WITH_NSPCG = 0
-endif
-
 # ----------------
 # Target directory
 # ----------------
@@ -283,6 +271,20 @@ ifeq ($(CLUSTER),x64_linux)
   SIMVASCULAR_PLATFORM = x64
   SIMVASCULAR_POSTFIX=
   SIMVASCULAR_OS=linux
+endif
+
+# by default don't build most third party
+# if we are only building the flow solver
+ifeq ($(EXCLUDE_ALL_BUT_THREEDSOLVER), 1)
+    ifeq ($(FLOWSOLVER_VERSION_USE_VTK_ACTIVATE), 0)
+        MAKE_WITH_VTK = 0
+    endif
+
+    MAKE_WITH_ITK = 0
+    MAKE_WITH_VMTK = 0
+    MAKE_WITH_TETGEN = 0
+    MAKE_WITH_SPARSE = 0
+    MAKE_WITH_NSPCG = 0
 endif
 
 # --------------
@@ -707,13 +709,20 @@ endif
 
 ifeq ($(MAKE_WITH_MPI),1)
 
+  MPI_NAME ?= mpi
+
   ifeq ($(CLUSTER), x64_cygwin)
 	include $(TOP)/MakeHelpers/msmpi.x64_cygwin.mk
   endif
 
   # on linux, use the OS installed version of mpich2
   ifeq ($(CLUSTER), x64_linux)
-	include $(TOP)/MakeHelpers/mpich2.usr.x64_linux.mk
+    ifeq ($(MAKE_WITH_OPENMPI),1)
+      include $(TOP)/MakeHelpers/openmpi.x64_linux.mk
+    endif
+    ifeq ($(MAKE_WITH_MPICH),1)
+      include $(TOP)/MakeHelpers/mpich.x64_linux.mk
+    endif
   endif
 
 endif


### PR DESCRIPTION
added new variables to makefile build:

MAKE_WITH_OPENMPI
MAKE_WITH_MPICH

which are mutually exclusive

the default is now "MAKE_WITH_OPENMPI=1"

these call scripts that attempt to autodetect the compiler flags for mpi