### PR TITLE
BUG: Made SetMeshOptions value argument required to avoid crashing

### DIFF
--- a/Code/Source/Mesh/MeshObject/cv_mesh_init.cxx
+++ b/Code/Source/Mesh/MeshObject/cv_mesh_init.cxx
@@ -1014,7 +1014,7 @@ static int cvMesh_SetMeshOptionsMtd( ClientData clientData, Tcl_Interp *interp,
   int table_size = 2;
   ARG_Entry arg_table[] = {
     { "-options", STRING_Type   , &flags, NULL, REQUIRED, 0 , { 0 }},
-    { "-values", LIST_Type   , &valueList, NULL, GDSC_OPTIONAL, 0 , { 0 }},
+    { "-values", LIST_Type   , &valueList, NULL, REQUIRED, 0 , { 0 }},
   };
 
   usage = ARG_GenSyntaxStr( 2, argv, table_size, arg_table );

--- a/Tcl/SimVascular_2.0/Plugins/tetgen.tcl
+++ b/Tcl/SimVascular_2.0/Plugins/tetgen.tcl
@@ -332,7 +332,7 @@ proc mesh_readTGS {filename resObj} {
              foreach lineval [lrange $line 1 end] {
 	      puts "[llength $lineval]"
 	      puts "$lineval"
-              $resObj SetMeshOptions -options $lineval
+              $resObj SetMeshOptions -options $lineval -values {1}
              }
 	  }
       } elseif {[lindex $line 0] == "getBoundaries"} {


### PR DESCRIPTION
Fixes error in Windows for crashing when values flag isn't sent in with SetMeshOptions