### PR TITLE
Made it possible to load polydata with ModelFaceID but no facenames file

### DIFF
--- a/Tcl/SimVascular_2.0/GUI/model.tcl
+++ b/Tcl/SimVascular_2.0/GUI/model.tcl
@@ -753,6 +753,14 @@ proc guiSV_model_load_model { {fn "" } } {
       }
       guiSV_model_add_faces_to_tree $kernel $inputName
       set withFaces 1
+    } elseif {[guiSV_model_check_array_exists $inputName 1 "ModelFaceID"]} {
+      catch {unset gPolyDataFaceNames}
+      set faceids [$inputName GetFaceIds]
+      foreach id $faceids {
+	set gPolyDataFaceNames($id) "noname_$id"
+      }
+      guiSV_model_add_faces_to_tree $kernel $inputName
+      set withFaces 1
     }
   }
   if {$kernel == "OpenCASCADE"} {


### PR DESCRIPTION
If a polydata is loaded without a corresponding .facenames file, but the array modelfaceid exists on the solid, the faces are loaded and given a noname_id name