### PR TITLE
Fix startup

### DIFF
--- a/Code/Source/Model/SolidModel/cvSolidModel.cxx
+++ b/Code/Source/Model/SolidModel/cvSolidModel.cxx
@@ -91,7 +91,7 @@ cvSolidModel* cvSolidModel::DefaultInstantiateSolidModel( Tcl_Interp *interp )
 
     solid = (cvSolidModel *) (solidModelRegistrar->UseFactoryMethod( cvSolidModel::gCurrentKernel ));
     if (solid == NULL) {
-		  fprintf( stdout, "Unable to create solid model kernal (%i)\n",cvSolidModel::gCurrentKernel);
+		  fprintf( stdout, "Unable to create solid model kernel (%i)\n",cvSolidModel::gCurrentKernel);
 		  //Tcl_SetResult( interp, "Unable to create solid model", TCL_STATIC );
     }
   } else {

--- a/Tcl/SimVascular_2.0/GUI/gui.tcl
+++ b/Tcl/SimVascular_2.0/GUI/gui.tcl
@@ -46877,9 +46877,23 @@ proc mainGUI {} {
   bind $tv <<TreeviewOpen>> [list guiSV_model_fillTree $tv]
   bind $tv <<TreeviewSelect>> [list guiSV_model_selectTree $tv]
   $tv insert {} 0 -id .models.PolyData -text "PolyData" -open 0
-  $tv insert {} 1 -id .models.Discrete -text "Discrete" -open 0
-  $tv insert {} 2 -id .models.Parasolid -text "Parasolid" -open 0
-  $tv insert {} 3 -id .models.OpenCASCADE -text "OpenCASCADE" -open 0
+  catch {repos_delete -obj /tmp/testsolid/obj}
+  solid_setKernel -name "Discrete"
+  if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+    $tv insert {} 1 -id .models.Discrete -text "Discrete" -open 0
+  }
+  catch {repos_delete -obj /tmp/testsolid/obj}
+  solid_setKernel -name "Parasolid"
+  if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+    $tv insert {} 2 -id .models.Parasolid -text "Parasolid" -open 0
+  }
+  catch {repos_delete -obj /tmp/testsolid/obj}
+  solid_setKernel -name "OpenCASCADE"
+  if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+    $tv insert {} 3 -id .models.OpenCASCADE -text "OpenCASCADE" -open 0
+  }
+  catch {repos_delete -obj /tmp/testsolid/obj}
+  solid_setKernel -name "PolyData"
 
   global symbolicName
   global guiTRIMvars

--- a/Tcl/SimVascular_2.0/GUI/gui.tcl
+++ b/Tcl/SimVascular_2.0/GUI/gui.tcl
@@ -46820,7 +46820,7 @@ proc mainGUI {} {
     ShowWindow.guiCV
     set swidth [expr [winfo screenwidth .]-10]
     set sheight [expr [winfo screenheight .]-10]
-    wm geometry .guiCV ${swidth}x${sheight}+10+10
+    wm geometry .guiCV ${swidth}x${sheight}+5+5
 
     guiFNMsetDefaultFilenames
     global gFilenames

--- a/Tcl/SimVascular_2.0/GUI/gui.tcl
+++ b/Tcl/SimVascular_2.0/GUI/gui.tcl
@@ -44,10 +44,12 @@ proc ShowWindow.guiCV { args} {
   }
   toplevel .guiCV   -background {white}
 
+  set wmax [winfo screenwidth .]
+  set hmax [winfo screenheight .]
   # Window manager configurations
   wm positionfrom .guiCV program
   wm sizefrom .guiCV program
-  wm maxsize .guiCV 2560 1600
+  wm maxsize .guiCV $wmax $hmax
   #wm minsize .guiCV 1890 1155
   wm minsize .guiCV 124 95
   wm protocol .guiCV WM_DELETE_WINDOW {mainGUIexit}
@@ -46816,7 +46818,9 @@ proc mainGUI {} {
     }
 
     ShowWindow.guiCV
-    wm geometry .guiCV 1000x500+360+170
+    set swidth [expr [winfo screenwidth .]-10]
+    set sheight [expr [winfo screenheight .]-10]
+    wm geometry .guiCV ${swidth}x${sheight}+10+10
 
     guiFNMsetDefaultFilenames
     global gFilenames

--- a/Tcl/SimVascular_2.0/GUI/model.tcl
+++ b/Tcl/SimVascular_2.0/GUI/model.tcl
@@ -1072,13 +1072,26 @@ proc guiSV_model_update_tree {} {
 
   if {[llength [model_names]] == 0} {
     $tv delete .models.PolyData
-    $tv delete .models.Parasolid
-    $tv delete .models.Discrete
-    $tv delete .models.OpenCASCADE
     $tv insert {} 0 -id .models.PolyData -text "PolyData" -open 0
-    $tv insert {} 1 -id .models.Discrete -text "Discrete" -open 0
-    $tv insert {} 2 -id .models.Parasolid -text "Parasolid" -open 0
-    $tv insert {} 3 -id .models.OpenCASCADE -text "OpenCASCADE" -open 0
+    catch {repos_delete -obj /tmp/testsolid/obj}
+    solid_setKernel -name "Discrete"
+    if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+      $tv delete .models.Discrete
+      $tv insert {} 1 -id .models.Discrete -text "Discrete" -open 0
+    }
+    catch {repos_delete -obj /tmp/testsolid/obj}
+    solid_setKernel -name "Parasolid"
+    if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+      $tv delete .models.Parasolid
+      $tv insert {} 2 -id .models.Parasolid -text "Parasolid" -open 0
+    }
+    catch {repos_delete -obj /tmp/testsolid/obj}
+    solid_setKernel -name "OpenCASCADE"
+    if {![catch {solid_newObject -name /tmp/testsolid/obj}]} {
+      $tv delete .models.OpenCASCADE
+      $tv insert {} 3 -id .models.OpenCASCADE -text "OpenCASCADE" -open 0
+    }
+    catch {repos_delete -obj /tmp/testsolid/obj}
   }
   $tv configure -columns [list DisplayModel FaceIds DisplayFaces]
   $tv heading \#0 -text "Object"

--- a/Tcl/SimVascular_2.0/simvascular_startup.tcl
+++ b/Tcl/SimVascular_2.0/simvascular_startup.tcl
@@ -424,15 +424,6 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   if [catch {tk::unsupported::ExposePrivateCommand tkTabToWindow}] {
     proc tkTabToWindow {foo} {}
   }
-
-  source [file join $env(SV_HOME)/Tcl/External/tkcon.tcl]
-  source [file join $env(SV_HOME)/Tcl/External/graph.tcl]
-
-  after 5000 {set splash_delay_done 1}
-  vwait splash_delay_done
-
-  DestroyWindow.splash
-
   # try and pick a nice looking theme if it exists
 
   if {$tcl_platform(os) == "Linux"} {
@@ -444,12 +435,24 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
      catch {ttk::style theme use vista}
   }
 
-  mainGUI
-  catch {wm withdraw .}
   if {$tcl_platform(os) == "Darwin"} {
      catch {ttk::style theme use aqua}
   }
 
+  source [file join $env(SV_HOME)/Tcl/External/tkcon.tcl]
+  source [file join $env(SV_HOME)/Tcl/External/graph.tcl]
+
+  #Start main gui but keep transparent while tkcon loads
+  #Wait for 8 seconds and then close the splash screen
+  #and show the main window with correct sizing
+  mainGUI
+  wm attributes .guiCV -alpha 0.0
+
+  after 8000 {set splash_delay_done 1}
+  vwait splash_delay_done
+
+  DestroyWindow.splash
+  wm attributes .guiCV -alpha 1.0
 
   # --------------------------------
   # aliases (alias proc is in Tkcon)
@@ -463,8 +466,6 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   set ::tkcon::COLOR(bg) white
   global symbolicName
 
-  after 5000 {set tkcon_delay_done 1}
-  vwait tkcon_delay_done
   if { $SV_NO_RENDERER == "1" } {
     puts "Starting up in no render mode"
   } else {
@@ -476,14 +477,14 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   set leftright $symbolicName(main_left_right_panedwindow)
 
   set w [winfo width $leftright]
-  #puts "width: $w"
-  set sash0 300
-  puts "sashpos: [$leftright sashpos 0 $sash0]"
+  puts "width: $w"
+  set sash0 [expr int($w/2)]
+  puts "vert sashpos: [$leftright sashpos 0 $sash0]"
 
   set h [winfo height $topbottom]
-  #puts "height: $h"
-  set sash0 320
-  puts "sashpos: [$topbottom sashpos 0 $sash0]"
+  puts "height: $h"
+  set sash0 [expr int($h/3)]
+  puts "horz sashpos: [$topbottom sashpos 0 $sash0]"
 
   if {[info exists env(SV_REDIRECT_STDERR_STDOUT)]} {
   proc handle { args } {

--- a/Tcl/SimVascular_2.0/simvascular_startup.tcl
+++ b/Tcl/SimVascular_2.0/simvascular_startup.tcl
@@ -426,6 +426,15 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   }
   # try and pick a nice looking theme if it exists
 
+  source [file join $env(SV_HOME)/Tcl/External/tkcon.tcl]
+  source [file join $env(SV_HOME)/Tcl/External/graph.tcl]
+
+  #Start main gui but keep transparent while tkcon loads
+  #Wait for 6 seconds and then close the splash screen
+  #and show the main window with correct sizing
+  mainGUI
+  wm attributes .guiCV -alpha 0.0
+
   if {$tcl_platform(os) == "Linux"} {
      catch {ttk::style theme use aqua}
   }
@@ -438,15 +447,6 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   if {$tcl_platform(os) == "Darwin"} {
      catch {ttk::style theme use aqua}
   }
-
-  source [file join $env(SV_HOME)/Tcl/External/tkcon.tcl]
-  source [file join $env(SV_HOME)/Tcl/External/graph.tcl]
-
-  #Start main gui but keep transparent while tkcon loads
-  #Wait for 8 seconds and then close the splash screen
-  #and show the main window with correct sizing
-  mainGUI
-  wm attributes .guiCV -alpha 0.0
 
   after 6000 {set splash_delay_done 1}
   vwait splash_delay_done

--- a/Tcl/SimVascular_2.0/simvascular_startup.tcl
+++ b/Tcl/SimVascular_2.0/simvascular_startup.tcl
@@ -448,7 +448,7 @@ if {[lsearch -exact $envnames SV_BATCH_MODE] < 0} {
   mainGUI
   wm attributes .guiCV -alpha 0.0
 
-  after 8000 {set splash_delay_done 1}
+  after 6000 {set splash_delay_done 1}
   vwait splash_delay_done
 
   DestroyWindow.splash


### PR DESCRIPTION
-Sets max width and height to screen width and height
-Sets initial size to slightly smaller than screen width and height
-Makes window transparent until it loads and splash screen exits
-Sets sashpos relative to the current window size
-Doesn't add model kernels to treeview unless they are available