### PR TITLE
fixed bug causing cmake to fail after building with make

### DIFF
--- a/BuildWithMake/Makefile
+++ b/BuildWithMake/Makefile
@@ -36,7 +36,7 @@ include $(TOP)/include.mk
 
 all:	mixed
 
-mixed: mksedscript pre-build static-build shared-build exec-build post-build
+mixed: mksedscript pre-build create-svsolver-options-file static-build shared-build exec-build post-build
 
 mksedscript:
 	if [ -e tclscript ];then /bin/rm -f tclscript;fi
@@ -213,9 +213,9 @@ pre-build:
 	cd ../Code/Source/UI;$(MAKE) MAKE_STATIC_BUILD=1 pre
 	mkdir -p Bin
 	mkdir -p Lib
-	touch ../Code/Source/Include/simvascular_options.h
-	touch ../Code/Source/Include/simvascular_version.h
-	touch ../Code/FlowSolvers/ThreeDSolver/cvFlowsolverOptions.h
+	mkdir -p ../Code/Source/Include/Make
+	touch ../Code/Source/Include/Make/simvascular_options.h
+	touch ../Code/Source/Include/Make/simvascular_version.h
 
 shared-build:
 	for i in ${SHARED_LIBDIRS}; do ( \
@@ -252,7 +252,7 @@ post-build: mksedscript
 	-sed -f sedscript $(TOP)/Release/developer_wrapper_scripts/developer-postsolver-script >> mypost
 ifeq ($(CLUSTER),x64_linux)
 	-sed -f sedscript $(TOP)/Release/developer_wrapper_scripts/developer-flowsolver-linux-script > mysolver
-else ($(CLUSTER),x64_macosx)
+elif ($(CLUSTER),x64_macosx)
 	-sed -f sedscript $(TOP)/Release/developer_wrapper_scripts/developer-flowsolver-macosx-script > mysolver
 else
 	-sed -f sedscript $(TOP)/Release/developer_wrapper_scripts/developer-flowsolver-windows-script > mysolver
@@ -262,6 +262,13 @@ endif
 	-chmod a+rx mysolver
 	-chmod a+rx mypost
 #	-rm -f sedscript
+
+create-svsolver-options-file:
+	mkdir -p $(TOP)/../Code/FlowSolvers/Include/Make
+	@echo "#define VER_CORONARY $(SV_THREEDSOLVER_USE_CORONARY)" > $(TOP)/../Code/FlowSolvers/Include/Make/cvFlowsolverOptions.h
+	@echo "#define VER_CLOSEDLOOP $(SV_THREEDSOLVER_USE_CLOSEDLOOP)" >> $(TOP)/../Code/FlowSolvers/Include/Make/cvFlowsolverOptions.h
+	@echo "#define VER_VARWALL $(SV_THREEDSOLVER_USE_VARWALL)" >> $(TOP)/../Code/FlowSolvers/Include/Make/cvFlowsolverOptions.h
+	@echo "#define VER_USE_VTK $(SV_THREEDSOLVER_USE_VTK)" >> $(TOP)/../Code/FlowSolvers/Include/Make/cvFlowsolverOptions.h
 
 clean:  veryclean
 
@@ -302,8 +309,10 @@ veryclean:
 	$(RM) $(TOP)/../Tcl/SimVascular_2.0/GUI/tclIndex
 	$(RM) $(TOP)/../Tcl/SimVascular_2.0/Core/tclIndex
 	$(RM) $(TOP)/../Tcl/SimVascular_2.0/Plugins/tclIndex
-	/bin/rm -f  ../Code/Source/Include/simvascular_options.h
-	/bin/rm -f  ../Code/Source/Include/simvascular_version.h
-	/bin/rm -f  ../Code/FlowSolvers/ThreeDSolver/cvFlowsolverOptions.h
+	/bin/rm -f  ../Code/Source/Include/Make/simvascular_options.h
+	/bin/rm -f  ../Code/Source/Include/Make/simvascular_version.h
+	/bin/rm -f  ../Code/FlowSolvers/Include/Make/cvFlowsolverOptions.h
+	/bin/rm -fR ../Code/Source/Include/Make
+	/bin/rm -fR ../Code/FlowSolvers/Include/Make
 	/bin/rm -f  sedscript
 

--- a/BuildWithMake/include.mk
+++ b/BuildWithMake/include.mk
@@ -620,7 +620,7 @@ endif
 
 ifeq ($(SV_USE_THREEDSOLVER),1)
      LIBDIRS += ../Code/FlowSolvers/ThreeDSolver
-     SOLVERIO_INCDIR = -I $(TOP)/../Code/FlowSolvers/ThreeDSolver/SolverIO
+     SOLVERIO_INCDIR = -I $(TOP)/../Code/FlowSolvers/ThreeDSolver/SolverIO -I $(TOP)/../Code/FlowSolvers/Include/Make
      THREEDSOLVER_INCDIR = -I $(TOP)/../Code/FlowSolvers/ThreeDSolver
      EXECDIRS += ../Code/FlowSolvers/ThreeDSolver
 endif
@@ -693,7 +693,7 @@ SUBDIRS         = $(LIBDIRS) $(EXECDIRS)
 # Local include directories
 # -------------------------
 
-LOCAL_SUBDIRS   = $(LIBDIRS) $(SHARED_LIBDIRS) ../Code/Source/Include
+LOCAL_SUBDIRS   = $(LIBDIRS) $(SHARED_LIBDIRS) ../Code/Source/Include ../Code/Source/Include/Make
 LOCAL_INCDIR    := $(foreach i, ${LOCAL_SUBDIRS}, -I$(TOP)/$(i))
 LOCAL_LIBDIR	=  -L$(TOP)/Lib
 LOCAL_LIBS	=  $(LOCAL_LIBDIR) -lsimvascular_utils

--- a/Code/FlowSolvers/ThreeDSolver/SolverIO/Makefile
+++ b/Code/FlowSolvers/ThreeDSolver/SolverIO/Makefile
@@ -47,7 +47,7 @@ include $(TOP)/include.mk
 # Compiler flags
 # --------------
 
-CXXFLAGS = $(GLOBAL_CXXFLAGS) $(ZLIB_INCDIR) -I..
+CXXFLAGS = $(GLOBAL_CXXFLAGS) $(ZLIB_INCDIR) -I../../Include/Make
 
 HDRS	= cvSolverIO.h
 

--- a/Code/FlowSolvers/ThreeDSolver/svPost/Makefile
+++ b/Code/FlowSolvers/ThreeDSolver/svPost/Makefile
@@ -40,7 +40,7 @@ include $(TOP)/include.mk
 # Compiler flags
 # --------------
 
-CXXFLAGS = $(GLOBAL_CXXFLAGS) $(LOCAL_INCDIR) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS)
+CXXFLAGS = $(GLOBAL_CXXFLAGS) $(LOCAL_INCDIR) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS) -I../../Include/Make
 
 HDRS	=
 
@@ -57,7 +57,7 @@ OBJS    = $(addprefix $(BUILD_DIR)/,$(CXXSRCS:.cxx=.$(OBJECTEXT))) \
 TARGET_EXE_FULL = $(TOP)/Bin/postsolver-$(CXX_COMPILER_VERSION)-$(FORTRAN_COMPILER_VERSION).exe
 TARGET_EXE = $(TOP)/Bin/postsolver.exe
 
-static: directories createOptionFile $(TARGET_EXE_FULL) 
+static: directories $(TARGET_EXE_FULL) 
 
 directories:
 	-mkdir -p $(BUILD_DIR)
@@ -78,17 +78,12 @@ ifndef NO_DEPEND
 -include $(DEPS)
 endif
 
-createOptionFile:
-	@echo "#define VER_CORONARY $(SV_THREEDSOLVER_USE_CORONARY)" > $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/cvFlowsolverOptions.h
-	@echo "#define VER_CLOSEDLOOP $(SV_THREEDSOLVER_USE_CLOSEDLOOP)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/cvFlowsolverOptions.h
-	@echo "#define VER_VARWALL $(SV_THREEDSOLVER_USE_VARWALL)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/cvFlowsolverOptions.h
-	@echo "#define VER_USE_VTK $(SV_THREEDSOLVER_USE_VTK)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/cvFlowsolverOptions.h
-
 clean:
 	for fn in $(BUILD_DIR); do /bin/rm -f -r $$fn;done
 	for fn in *~; do /bin/rm -f $$fn;done
 	for fn in $(TOP)/Bin/$(TARGET_EXE)*; do /bin/rm -f $$fn; done
-	/bin/rm -f cvFlowsolverOptions.h
+	/bin/rm -f $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/Make/cvFlowsolverOptions.h
+	/bin/rm -fR $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPost/Make
 
 veryclean: clean
 	if [ -e obj ];then /bin/rm -f -r obj;fi

--- a/Code/FlowSolvers/ThreeDSolver/svPre/Makefile
+++ b/Code/FlowSolvers/ThreeDSolver/svPre/Makefile
@@ -46,9 +46,9 @@ include $(TOP)/include.mk
 # Compiler flags
 # --------------
 
-CXXFLAGS = $(GLOBAL_CXXFLAGS) $(LOCAL_INCDIR) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(VTK_INCDIRS) $(NSPCG_INCDIR) $(ZLIB_INCDIR)
-CCFLAGS  = $(GLOBAL_CXXFLAGS) $(SPARSE_INCDIR) $(ZLIB_INCDIR) $(THREEDSOLVER_INCDIR)
-FFLAGS   = $(GLOBAL_FFLAGS) $(NSPCG_INCDIR) $(THREEDSOLVER_INCDIR)
+CXXFLAGS = $(GLOBAL_CXXFLAGS) $(LOCAL_INCDIR) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(VTK_INCDIRS) $(NSPCG_INCDIR) $(ZLIB_INCDIR) -I../../Include/Make
+CCFLAGS  = $(GLOBAL_CXXFLAGS) $(SPARSE_INCDIR) $(ZLIB_INCDIR) $(THREEDSOLVER_INCDIR) -I../../Include/Make
+FFLAGS   = $(GLOBAL_FFLAGS) $(NSPCG_INCDIR) $(THREEDSOLVER_INCDIR) -I../../Include/Make
 
 HDRS	= cmd.h
 
@@ -84,7 +84,7 @@ OBJS    = $(addprefix $(BUILD_DIR)/,$(CXXSRCS:.cxx=.$(OBJECTEXT))) \
 TARGET_EXE_FULL = $(TOP)/Bin/presolver-$(CXX_COMPILER_VERSION)-$(FORTRAN_COMPILER_VERSION).exe
 TARGET_EXE = $(TOP)/Bin/presolver.exe
 
-static: directories createOptionFile $(TARGET_EXE_FULL) 
+static: directories $(TARGET_EXE_FULL) 
 
 directories:
 	-mkdir -p $(BUILD_DIR)
@@ -106,17 +106,10 @@ ifndef NO_DEPEND
 -include $(DEPS)
 endif
 
-createOptionFile:
-	@echo "#define VER_CORONARY $(SV_THREEDSOLVER_USE_CORONARY)" > $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPre/cvFlowsolverOptions.h
-	@echo "#define VER_CLOSEDLOOP $(SV_THREEDSOLVER_USE_CLOSEDLOOP)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPre/cvFlowsolverOptions.h
-	@echo "#define VER_VARWALL $(SV_THREEDSOLVER_USE_VARWALL)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPre/cvFlowsolverOptions.h
-	@echo "#define VER_USE_VTK $(SV_THREEDSOLVER_USE_VTK)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svPre/cvFlowsolverOptions.h
-
 clean:
 	for fn in $(BUILD_DIR); do /bin/rm -f -r $$fn;done
 	for fn in *~; do /bin/rm -f $$fn;done
 	for fn in $(TOP)/Bin/$(TARGET_EXE)*; do /bin/rm -f $$fn; done
-	/bin/rm -f cvFlowsolverOptions.h
 
 veryclean: clean
 	if [ -e obj ];then /bin/rm -f -r obj;fi

--- a/Code/FlowSolvers/ThreeDSolver/svSolver/Makefile
+++ b/Code/FlowSolvers/ThreeDSolver/svSolver/Makefile
@@ -50,9 +50,9 @@ include $(TOP)/include.mk
 # Compiler flags
 # --------------
 
-CXXFLAGS = $(GLOBAL_CXXFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(LESLIB_INCDIR) $(LESLIB_DEFS) $(SVLS_INCDIR) $(SVLS_DEFS) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS)
-CCFLAGS  = $(GLOBAL_CCFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(LESLIB_INCDIR) $(LESLIB_DEFS) $(SVLS_INCDIR) $(SVLS_DEFS) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS)
-FFLAGS   = $(GLOBAL_FFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(SVLS_INCDIR) $(SVLS_DEFS) $(THREEDSOLVER_INCDIR)
+CXXFLAGS = $(GLOBAL_CXXFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(LESLIB_INCDIR) $(LESLIB_DEFS) $(SVLS_INCDIR) $(SVLS_DEFS) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS) -I../../Include/Make
+CCFLAGS  = $(GLOBAL_CCFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(LESLIB_INCDIR) $(LESLIB_DEFS) $(SVLS_INCDIR) $(SVLS_DEFS) $(SOLVERIO_INCDIR) $(THREEDSOLVER_INCDIR) $(ZLIB_INCDIR) $(VTK_INCDIRS) -I../../Include/Make
+FFLAGS   = $(GLOBAL_FFLAGS) $(MPI_INCDIR) $(METIS_INCDIR) $(SVLS_INCDIR) $(SVLS_DEFS) $(THREEDSOLVER_INCDIR) -I../../Include/Make
 
 # auxmpi.h and common.h are fortran headers
 HDRS	= Input.h ValType.h common_c.h
@@ -146,7 +146,7 @@ OBJS    = $(addprefix $(BUILD_MPI_DIR)/,$(CXXSRCS:.cxx=.$(OBJECTEXT))) \
 TARGET_EXE_FULL = $(TOP)/Bin/flowsolver-$(CXX_COMPILER_VERSION)-$(FORTRAN_COMPILER_VERSION)-$(MPI_NAME).exe
 TARGET_EXE = $(TOP)/Bin/flowsolver-$(MPI_NAME).exe
 
-static: directories createOptionFile $(TARGET_EXE_FULL) 
+static: directories $(TARGET_EXE_FULL) 
 
 directories:
 	-mkdir -p $(BUILD_MPI_DIR)
@@ -168,17 +168,10 @@ ifndef NO_DEPEND
 -include $(DEPS)
 endif
 
-createOptionFile:
-	@echo "#define VER_CORONARY $(SV_THREEDSOLVER_USE_CORONARY)" > $(TOP)/../Code/FlowSolvers/ThreeDSolver/svSolver/cvFlowsolverOptions.h
-	@echo "#define VER_CLOSEDLOOP $(SV_THREEDSOLVER_USE_CLOSEDLOOP)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svSolver/cvFlowsolverOptions.h
-	@echo "#define VER_VARWALL $(SV_THREEDSOLVER_USE_VARWALL)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svSolver/cvFlowsolverOptions.h
-	@echo "#define VER_USE_VTK $(SV_THREEDSOLVER_USE_VTK)" >> $(TOP)/../Code/FlowSolvers/ThreeDSolver/svSolver/cvFlowsolverOptions.h
-
 clean:
 	for fn in $(BUILD_DIR); do /bin/rm -f -r $$fn;done
 	for fn in *~; do /bin/rm -f $$fn;done
 	for fn in $(TOP)/Bin/$(TARGET_EXE)*; do /bin/rm -f $$fn; done
-	/bin/rm -f cvFlowsolverOptions.h
 
 veryclean: clean
 	if [ -e obj ];then /bin/rm -f -r obj;fi


### PR DESCRIPTION
  when building use make, it creates *.h files that confuse
  cmake build.  Moved autogenerated *.h files into subdirectories
  outside the view of cmake.