### PR TITLE
DEV: Edit polydata normals filters

### DIFF
--- a/Code/Source/Common/Geometry/cv_sys_geom.cxx
+++ b/Code/Source/Common/Geometry/cv_sys_geom.cxx
@@ -3728,6 +3728,8 @@ int sys_geom_local_laplacian_smooth( cvPolyData *pd,cvPolyData **outpd, int numi
 
     vtkNew(vtkPolyDataNormals,normaler);
     normaler->SetInputData(smoother->GetOutput());
+    normaler->ComputePointNormalsOff();
+    normaler->ComputeCellNormalsOn();
     normaler->SplittingOff();
     normaler->Update();
 
@@ -3798,6 +3800,8 @@ int sys_geom_local_constrain_smooth( cvPolyData *pd,cvPolyData **outpd, int numi
 
     vtkNew(vtkPolyDataNormals,normaler);
     normaler->SetInputData(smoother->GetOutput());
+    normaler->ComputePointNormalsOff();
+    normaler->ComputeCellNormalsOn();
     normaler->SplittingOff();
     normaler->Update();
 

--- a/Code/Source/Mesh/MMGMeshUtils/cv_mmg_mesh_utils.cxx
+++ b/Code/Source/Mesh/MMGMeshUtils/cv_mmg_mesh_utils.cxx
@@ -432,9 +432,9 @@ int MMGUtils_SurfaceRemeshing(vtkPolyData *surface, double hmin, double hmax, do
   normaler->ConsistencyOn();
   normaler->AutoOrientNormalsOn();
   normaler->FlipNormalsOff();
-  normaler->ComputePointNormalsOn();
-  normaler->ComputeCellNormalsOff();
-  normaler->SplittingOn();
+  normaler->ComputePointNormalsOff();
+  normaler->ComputeCellNormalsOn();
+  normaler->SplittingOff();
   normaler->Update();
 
   surface->DeepCopy(normaler->GetOutput());

--- a/Code/Source/Modules/Model/svModelUtils.cxx
+++ b/Code/Source/Modules/Model/svModelUtils.cxx
@@ -394,7 +394,7 @@ vtkPolyData* svModelUtils::Orient(vtkPolyData* inpd)
     vtkSmartPointer<vtkPolyDataNormals> orienter = vtkSmartPointer<vtkPolyDataNormals>::New();
     orienter->SetInputData(cleaner->GetOutput());
     orienter->AutoOrientNormalsOn();
-    orienter->ComputePointNormalsOn();
+    orienter->ComputePointNormalsOff();
     orienter->FlipNormalsOn();
     orienter->SplittingOff();
     orienter->ComputeCellNormalsOn();
@@ -500,7 +500,7 @@ vtkSmartPointer<vtkPolyData> svModelUtils::OrientVtkPolyData(vtkSmartPointer<vtk
     vtkSmartPointer<vtkPolyDataNormals> orienter=vtkSmartPointer<vtkPolyDataNormals>::New();
     orienter->SetInputDataObject(cleaner->GetOutput());
     orienter->AutoOrientNormalsOn();
-    orienter->ComputePointNormalsOn();
+    orienter->ComputePointNormalsOff();
     orienter->FlipNormalsOn();
     orienter->SplittingOff();
     orienter->ComputeCellNormalsOn();


### PR DESCRIPTION
If using normals filter, turn off point normals otherwise visualization looks weird
Also make sure splitting is off so that duplicate points are not used in operation such as remeshing