### PR TITLE
2017-01-13-use-svsolver-registry

### DIFF
--- a/BuildWithMake/Release/Makefile
+++ b/BuildWithMake/Release/Makefile
@@ -296,6 +296,7 @@ ifeq ($(SV_USE_MITK),1)
 	-cp -fR $(MITK_BINDIRS)/MitkPython $(DIST_DIR)/mitk/bin
 	-cp -fR $(MITK_BINDIRS)/Python $(DIST_DIR)/mitk/bin
 	-cp -f $(SV_MITK_SO_PATH)/*.$(SOEXT)* $(DIST_DIR)
+	-cp -fR $(MITK_BINDIRS)/dcm* $(DIST_DIR)
 ifeq ($(CLUSTER), x64_cygwin)
 	-mkdir -p $(DIST_DIR)/mitk/bin/plugins
 	-cp -fR $(SV_MITK_PLUGIN_PATH) $(DIST_DIR)/mitk/bin/plugins

--- a/Tcl/SimVascular_2.0/GUI/gui.tcl
+++ b/Tcl/SimVascular_2.0/GUI/gui.tcl
@@ -30834,7 +30834,7 @@ proc guiMMcreateCondensedFile {} {
   }
 
   global gExternalPrograms
-  set cvpost $gExternalPrograms(cvpostsolver)
+  set cvpost $gExternalPrograms(svpost)
   puts "PostSolver Dir"
   puts $cvpost
 
@@ -30842,7 +30842,7 @@ proc guiMMcreateCondensedFile {} {
 
   global gFilenames
   set gFilenames(solution_file) $guiMMvars(error_input_dir)/restart.$stepnum.0
-  #tk_messageBox -message $msg -title "cvpostsolver output" -icon info -type ok
+  #tk_messageBox -message $msg -title "svpost output" -icon info -type ok
   guiSVMSGshow $msg
 }
 
@@ -31822,7 +31822,7 @@ proc guiMMwriteSUPRE {} {
     set [lindex $i 0] [lindex $i 1]
   }
 
-  puts "Create script file for cvpresolver."
+  puts "Create script file for svpre."
   set fp [open $gFilenames(supre_script_file) w]
   puts $fp "number_of_variables 5"
   puts $fp "number_of_nodes $number_of_nodes"
@@ -32096,10 +32096,10 @@ proc guiPHASTArunSupre {} {
 
   global gFilenames
 
-  set yesno [tk_messageBox -message "Run cvpresolver?" -default no -icon question -type yesno]
+  set yesno [tk_messageBox -message "Run svpre?" -default no -icon question -type yesno]
   if {$yesno == "no"} {return}
 
-  set yesno [tk_messageBox -message "Use currently loaded cvpresolver script?  This will save/overwrite the cvpresolver script file." -default yes -icon question -type yesno]
+  set yesno [tk_messageBox -message "Use currently loaded svpre script?  This will save/overwrite the svpre script file." -default yes -icon question -type yesno]
   if {$yesno == "yes"} {
     guiPHASTAsaveSupreFile
   }
@@ -32108,12 +32108,12 @@ proc guiPHASTArunSupre {} {
 
   global gExternalPrograms
 
-  catch {exec $gExternalPrograms(cvpresolver) $fn} msg
+  catch {exec $gExternalPrograms(svpre) $fn} msg
   set fp [open "$fn.log" w]
-  puts $fp "Executing:  $gExternalPrograms(cvpresolver) $fn >& $fn.log"
+  puts $fp "Executing:  $gExternalPrograms(svpre) $fn >& $fn.log"
   puts $fp $msg
   close $fp
-  #tk_messageBox -message $msg -title "cvpresolver output" -icon info -type ok
+  #tk_messageBox -message $msg -title "svpre output" -icon info -type ok
   guiSVMSGshow $msg
 }
 
@@ -32302,10 +32302,10 @@ proc guiPOSTconvertFilesToVTK {} {
   }
   set cmdstr "-all -indir \"$indir\" -outdir \"$outdir\" $vtkcombo $simunitsflag -start $start -stop $stop -incr $increment $makevtu $vtufn $makevtp $vtpfn $laststep $wallflag $wallfile $calcws $applywd $muflag $mu"
 
-  puts "executing cvpostsolver with cmdstr: $cmdstr"
+  puts "executing svpost with cmdstr: $cmdstr"
 
   global gExternalPrograms
-  catch {eval exec \"$gExternalPrograms(cvpostsolver)\" $cmdstr} msg
+  catch {eval exec \"$gExternalPrograms(svpost)\" $cmdstr} msg
   guiSVMSGshow $msg
 }
 
@@ -32348,7 +32348,7 @@ proc guiPOSTp2vis {} {
   }
 
   global gExternalPrograms
-  set cvpost $gExternalPrograms(cvpostsolver)
+  set cvpost $gExternalPrograms(svpost)
 
   for {set i $startnum} {$i <= $endnum} {incr i $incrnum} {
     puts "creating file $prefix\_res$i.vis"
@@ -36435,12 +36435,16 @@ proc guiRUNSOLVERlaunchSolver { system} {
   puts "Run Solver."
 
   global gExternalPrograms
-  set PRESOLVER     $gExternalPrograms(cvpresolver)
-  set POSTSOLVER    $gExternalPrograms(cvpostsolver)
+  set PRESOLVER     $gExternalPrograms(svpre)
+  set POSTSOLVER    $gExternalPrograms(svpost)
   set MPIEXEC       $gExternalPrograms(mpiexec)
-  set SOLVER        $gExternalPrograms(cvflowsolver)
-  set FLOWSOLVER_CONFIG [file dirname $gExternalPrograms(cvflowsolver)]
-  set ADAPTOR       $gExternalPrograms(cvadaptor)
+  if {$num_procs == 1} {
+      set SOLVER        $gExternalPrograms(svsolver-nompi)
+      set FLOWSOLVER_CONFIG [file dirname $gExternalPrograms(svsolver-nompi)]
+  } else {
+      set SOLVER        $gExternalPrograms(svsolver-mpi)
+      set FLOWSOLVER_CONFIG [file dirname $gExternalPrograms(svsolver-mpi)]
+  }
 
   set stdout_file $guiRUNSOLVERvars(log_dir)
 

--- a/Tcl/SimVascular_2.0/GUI/gui.tcl
+++ b/Tcl/SimVascular_2.0/GUI/gui.tcl
@@ -36438,7 +36438,7 @@ proc guiRUNSOLVERlaunchSolver { system} {
   set PRESOLVER     $gExternalPrograms(svpre)
   set POSTSOLVER    $gExternalPrograms(svpost)
   set MPIEXEC       $gExternalPrograms(mpiexec)
-  if {$num_procs == 1} {
+  if {$system == "no_mpi"} {
       set SOLVER        $gExternalPrograms(svsolver-nompi)
       set FLOWSOLVER_CONFIG [file dirname $gExternalPrograms(svsolver-nompi)]
   } else {

--- a/Tcl/SimVascular_2.0/simvascular_startup.tcl
+++ b/Tcl/SimVascular_2.0/simvascular_startup.tcl
@@ -469,25 +469,27 @@ if {[file exists [file join $simvascular_home/Tcl/externals_configure.tcl]] } {
   if {$SV_RELEASE_BUILD != 1} {
 
     # developer build
-    set gExternalPrograms(cvpresolver)  [file join $executable_home presolver$execbinext]
-    set gExternalPrograms(cvpostsolver) [file join $simvascular_home mypost]
-    set gExternalPrograms(cvflowsolver) [file join $simvascular_home mysolver]
-    set gExternalPrograms(mpiexec)      mpiexec
-    set gExternalPrograms(dicom2)       [file join $simvascular_home dicom2$execext]
-    set gExternalPrograms(dcmodify)     dcmodify$execext
-    set gExternalPrograms(dcmdump)      $rundir dcmdump$execext
-    set gExternalPrograms(gdcmdump)     $rundir gdcmdump$execext
+    set gExternalPrograms(svpre)          [file join $simvascular_home mypre]
+    set gExternalPrograms(svpost)         [file join $simvascular_home mypost]
+    set gExternalPrograms(svsolver-nompi) [file join $simvascular_home mysolver-nompi]
+    set gExternalPrograms(svsolver-mpi)   [file join $simvascular_home mysolver-mpi]
+    set gExternalPrograms(mpiexec)        mpiexec
+    set gExternalPrograms(dicom2)         [file join $simvascular_home dicom2$execext]
+    set gExternalPrograms(dcmodify)       dcmodify$execext
+    set gExternalPrograms(dcmdump)        dcmdump$execext
+    set gExternalPrograms(gdcmdump)       gdcmdump$execext
 
   } else {
 
      # installed release build
-     set gExternalPrograms(cvpresolver)  [file join $executable_home presolver$execbinext]
-     set gExternalPrograms(cvpostsolver) [file join $executable_home postsolver$execbinext]
-     set gExternalPrograms(cvflowsolver) [file join $executable_home flowsolver$execbinext]
-     set gExternalPrograms(mpiexec)      mpiexec
-     set gExternalPrograms(dicom2)       [file join $simvascular_home dicom2$execext]
-     set gExternalPrograms(dcmdump)      [file join $simvascular_home dcmdump$execext]
-     set gExternalPrograms(gdcmdump)     [file join $simvascular_home gdcmdump$execext]
+     set gExternalPrograms(svpre)          [file join $executable_home svpre$execbinext]
+     set gExternalPrograms(svpost)         [file join $executable_home svpost$execbinext]
+     set gExternalPrograms(svsolver-nompi) [file join $executable_home svsolver-nompi$execbinext]
+     set gExternalPrograms(svsolver-mpi)   [file join $executable_home svsolver-mpi$execbinext]
+     set gExternalPrograms(mpiexec)        mpiexec
+     set gExternalPrograms(dicom2)         [file join $simvascular_home dicom2$execext]
+     set gExternalPrograms(dcmdump)        [file join $simvascular_home dcmdump$execext]
+     set gExternalPrograms(gdcmdump)       [file join $simvascular_home gdcmdump$execext]
 
      # use registry to find seperately installed svsolver package on windows
      if {$tcl_platform(platform) == "windows"} {	
@@ -497,7 +499,7 @@ if {[file exists [file join $simvascular_home/Tcl/externals_configure.tcl]] } {
        if {$svpre_exe != ""} {		    
 	  if [file exists $svpre_exe] {
 	      puts "Found svPre ($svpre_exe)"
-	      set gExternalPrograms(cvpresolver) $svpre_exe
+	      regsub -all {\\} $svpre_exe / gExternalPrograms(svpre)
 	  }
        }
        set svpost_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
@@ -506,16 +508,25 @@ if {[file exists [file join $simvascular_home/Tcl/externals_configure.tcl]] } {
        if {$svpost_exe != ""} {		    
 	  if [file exists $svpost_exe] {
 	      puts "Found svPost ($svpost_exe)"
-	      set gExternalPrograms(cvpostsolver) $svpost_exe
+	      regsub -all {\\} $svpost_exe / gExternalPrograms(svpost)
 	  }
        }
-       set svsolver_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
+       set svsolver_nompi_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
 			                        HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\svSolver \
-				                SVSOLVER_EXE]
-       if {$svsolver_exe != ""} {		    
-	  if [file exists $svsolver_exe] {
-	      puts "Found svSolver ($svsolver_exe)"
-	      set gExternalPrograms(cvflowsolver) $svsolver_exe
+				                SVSOLVER_NOMPI_EXE]
+       if {$svsolver_nompi_exe != ""} {		    
+	  if [file exists $svsolver_nompi_exe] {
+	      puts "Found svSolver ($svsolver_nompi_exe)"
+	      regsub -all {\\} $svsolver_nompi_exe / gExternalPrograms(svsolver-nompi)
+	  }
+       }
+       set svsolver_msmpi_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
+			                        HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\svSolver \
+				                SVSOLVER_MSMPI_EXE]
+       if {$svsolver_msmpi_exe != ""} {		    
+	  if [file exists $svsolver_msmpi_exe] {
+	      puts "Found svSolver ($svsolver_msmpi_exe)"
+	      regsub -all {\\} $svsolver_msmpi_exe / gExternalPrograms(svsolver-mpi)
 	  }
        }
      }

--- a/Tcl/SimVascular_2.0/simvascular_startup.tcl
+++ b/Tcl/SimVascular_2.0/simvascular_startup.tcl
@@ -450,81 +450,77 @@ if {$tcl_platform(platform) == "windows"} {
   }
 }
 
-# for windows, we call the executables directly so don't append
-# "32" to names like on linux when running 32-bit versions
+#
+#  Set the paths to external binaries called by the GUI
+#
+
 global gExternalPrograms
+
+# cmake build directly creates a tcl script with the executable paths
 if {[file exists [file join $simvascular_home/Tcl/externals_configure.tcl]] } {
-  source [file join $simvascular_home/Tcl/externals_configure.tcl]
+
+    source [file join $simvascular_home/Tcl/externals_configure.tcl]
+
+} else {
+	
+  set executable_home $simvascular_home
+  set gExternalPrograms(rundir) $rundir
+
+  if {$SV_RELEASE_BUILD != 1} {
+
+    # developer build
+    set gExternalPrograms(cvpresolver)  [file join $executable_home presolver$execbinext]
+    set gExternalPrograms(cvpostsolver) [file join $simvascular_home mypost]
+    set gExternalPrograms(cvflowsolver) [file join $simvascular_home mysolver]
+    set gExternalPrograms(mpiexec)      mpiexec
+    set gExternalPrograms(dicom2)       [file join $simvascular_home dicom2$execext]
+    set gExternalPrograms(dcmodify)     dcmodify$execext
+    set gExternalPrograms(dcmdump)      $rundir dcmdump$execext
+    set gExternalPrograms(gdcmdump)     $rundir gdcmdump$execext
+
   } else {
-    set executable_home $simvascular_home
-    if {($SV_VERSION == "simvascular32") && ($tcl_platform(platform) != "windows")} {
-      set gExternalPrograms(cvpresolver) [file join $rundir presolver32$execbinext]
-      set gExternalPrograms(cvpostsolver) [file join $rundir postsolver32$execbinext]
-      set gExternalPrograms(cvadaptor) [file join $rundir adaptor32$execbinext]
-      set gExternalPrograms(cvtetadaptor) [file join $rundir tetadaptor32$execbinext]
-      set gExternalPrograms(cvflowsolver) [file join $rundir flowsolver32$execbinext]
-      set gExternalPrograms(cvsolver) [file join $rundir solver32$execext]
-      set gExternalPrograms(mpiexec) mpiexec
-      set gExternalPrograms(dicom2) [file join $rundir dicom2$execext]
-      if {$tcl_platform(platform) == "windows"} {
-        set gExternalPrograms(dcmodify) [file join $rundir dcmodify$execext]
-        set gExternalPrograms(dcmdump) [file join $rundir dcmdump$execext]
-        } else {
-          set gExternalPrograms(dcmodify) dcmodify
-          set gExternalPrograms(dcmdump) dcmdump
-        }
-        set gExternalPrograms(gdcmdump) gdcmdump
-        set gExternalPrograms(rundir) $rundir
-        } else {
-          if {$SV_RELEASE_BUILD == 1} {
-            set gExternalPrograms(cvpresolver) [file join $executable_home presolver$execbinext]
-            set gExternalPrograms(cvpostsolver) [file join $executable_home postsolver$execbinext]
-	    set gExternalPrograms(cvadaptor) [file join $executable_home adaptor$execbinext]
-	    if {$tcl_platform(platform) == "windows"} {
-	      if {![file exists $gExternalPrograms(cvadaptor)]} {
-                  set meshsimdll [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\Modules\\ParasolidAndMeshSim \
-			         HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\Modules\\ParasolidAndMeshSim \
-				 SV_MESHSIM_MESH_DLL]
-		  if {$meshsimdll != ""} {
-		      set gExternalPrograms(cvadaptor) [file join [file dirname $meshsimdll] [file tail $gExternalPrograms(cvadaptor)]]
-		  }
-	      }
-	    }
-            set gExternalPrograms(cvtetadaptor) [file join $executable_home tetadaptor$execbinext]
-            set gExternalPrograms(cvflowsolver) [file join $executable_home flowsolver$execbinext]
-            #    set gExternalPrograms(cvsolver) [file join $simvascular_home solver$execext]
-            #    TODO What to do for mpiexec?
-            set gExternalPrograms(mpiexec) mpiexec
-            set gExternalPrograms(dicom2) [file join $simvascular_home dicom2$execext]
-            } else {
-              set gExternalPrograms(cvpresolver) [file join $executable_home presolver$execbinext]
-              set gExternalPrograms(cvpostsolver) [file join $simvascular_home mypost]
-              set gExternalPrograms(cvadaptor) [file join $simvascular_home myadaptor]
-              set gExternalPrograms(cvtetadaptor) [file join $simvascular_home mytetadaptor]
-              set gExternalPrograms(cvflowsolver) [file join $simvascular_home mysolver]
-              #    set gExternalPrograms(cvsolver) [file join $simvascular_home mysolver$execext]
-              #    TODO What to do for mpiexec?
-              set gExternalPrograms(mpiexec) mpiexec
-              set gExternalPrograms(dicom2) [file join $simvascular_home dicom2$execext]
 
-            }
-            if {$tcl_platform(platform) == "windows"} {
-              set gExternalPrograms(dcmodify) [file join $rundir dcmodify$execext]
-              set gExternalPrograms(dcmdump) [file join $rundir dcmdump$execext]
-              } else {
-                set gExternalPrograms(dcmodify) dcmodify
-                set gExternalPrograms(dcmdump) dcmdump
-              }
-              set gExternalPrograms(gdcmdump) gdcmdump
-              set gExternalPrograms(rundir) $rundir
-            }
+     # installed release build
+     set gExternalPrograms(cvpresolver)  [file join $executable_home presolver$execbinext]
+     set gExternalPrograms(cvpostsolver) [file join $executable_home postsolver$execbinext]
+     set gExternalPrograms(cvflowsolver) [file join $executable_home flowsolver$execbinext]
+     set gExternalPrograms(mpiexec)      mpiexec
+     set gExternalPrograms(dicom2)       [file join $simvascular_home dicom2$execext]
+     set gExternalPrograms(dcmdump)      [file join $simvascular_home dcmdump$execext]
+     set gExternalPrograms(gdcmdump)     [file join $simvascular_home gdcmdump$execext]
 
-            # try and find the default mpiexec on ubuntu
-            #if {$tcl_platform(platform) != "windows" && $SV_RELEASE_BUILD} {
-            #  set gExternalPrograms(mpiexec) [file join $env(SV_HOME) [file tail $gExternalPrograms(mpiexec)]]
-            #}
-
-          }
+     # use registry to find seperately installed svsolver package on windows
+     if {$tcl_platform(platform) == "windows"} {	
+       set svpre_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
+			                     HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\svSolver \
+				             SVPRE_EXE]
+       if {$svpre_exe != ""} {		    
+	  if [file exists $svpre_exe] {
+	      puts "Found svPre ($svpre_exe)"
+	      set gExternalPrograms(cvpresolver) $svpre_exe
+	  }
+       }
+       set svpost_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
+		  	                      HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\svSolver \
+				              SVPOST_EXE]
+       if {$svpost_exe != ""} {		    
+	  if [file exists $svpost_exe] {
+	      puts "Found svPost ($svpost_exe)"
+	      set gExternalPrograms(cvpostsolver) $svpost_exe
+	  }
+       }
+       set svsolver_exe [modules_registry_query HKEY_LOCAL_MACHINE\\SOFTWARE\\SimVascular\\svSolver \
+			                        HKEY_LOCAL_MACHINE\\SOFTWARE\\Wow6432Node\\SimVascular\\svSolver \
+				                SVSOLVER_EXE]
+       if {$svsolver_exe != ""} {		    
+	  if [file exists $svsolver_exe] {
+	      puts "Found svSolver ($svsolver_exe)"
+	      set gExternalPrograms(cvflowsolver) $svsolver_exe
+	  }
+       }
+     }
+   }		   
+}
 
 #
 #  use registry to find mpiexec on windows


### PR DESCRIPTION
DEV: updated Windows registry to use new names of external executables (e.g. svsolver), also now can call either the nompi or mpi version of svsolver