### PR TITLE
2017 03 29 nurbs lofting

### DIFF
--- a/Code/CMake/SimVascularDependentOptions.cmake
+++ b/Code/CMake/SimVascularDependentOptions.cmake
@@ -275,5 +275,15 @@ if(SV_USE_QT_GUI)
 
   set(SV_USE_PYTHON "ON" CACHE BOOL "Force ON" FORCE)
   set(SV_USE_PYTHON_SHARED "ON" CACHE BOOL "Force ON" FORCE)
+
+  if(SV_USE_OpenCASCADE)
+    set(SV_USE_OpenCASCADE_QT_GUI "ON" CACHE BOOL "Force ON" FORCE)
+  endif()
+  if(SV_USE_PARASOLID)
+    set(SV_USE_PARASOLID_QT_GUI "ON" CACHE BOOL "Force ON" FORCE)
+  endif()
+  if(SV_USE_MESHSIM)
+    set(SV_USE_MESHSIM_QT_GUI "ON" CACHE BOOL "Force ON" FORCE)
+  endif()
 endif()
 #-----------------------------------------------------------------------------

--- a/Code/CMake/SimVascularMacros.cmake
+++ b/Code/CMake/SimVascularMacros.cmake
@@ -1104,6 +1104,8 @@ endfunction()
 macro(simvascular_add_new_external proj version use shared dirname)
   option(SV_USE_${proj} "Enable ${proj} Plugin" ${use})
   option(SV_USE_${proj}_SHARED "Build ${proj} libraries as shared libs" ${shared})
+  option(SV_USE_${proj}_QT_GUI "Build ${proj} in the Qt GUI" ${use})
+  mark_as_advanced(SV_USE_${proj}_QT_GUI)
 
   set(${proj}_VERSION "${version}" CACHE TYPE STRING)
   simvascular_get_major_minor_version(${${proj}_VERSION} ${proj}_MAJOR_VERSION ${proj}_MINOR_VERSION)

--- a/Code/CMake/SimVascularOptions.cmake
+++ b/Code/CMake/SimVascularOptions.cmake
@@ -127,11 +127,15 @@ option(SV_USE_SOLVERIO "Use SolverIO" OFF)
 #-----------------------------------------------------------------------------
 # Commercial Software Options: Solid Models - Parasolid
 option(SV_USE_PARASOLID "Parasolid" OFF)
+option(SV_USE_PARASOLID_QT_GUI "Parasolid" OFF)
+mark_as_advanced(SV_USE_PARASOLID_QT_GUI)
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------
 # MeshSim
 option(SV_USE_MESHSIM "Use MeshSim commercial libraries.  Requires licenese" OFF)
+option(SV_USE_MESHSIM_QT_GUI "Use MeshSim commercial libraries.  Requires licenese" OFF)
+mark_as_advanced(SV_USE_MESHSIM_QT_GUI)
 
 option(SV_USE_MESHSIM_ADAPTOR "Build the adapter (Requires Fortran and MeshSim)" OFF)
 #-----------------------------------------------------------------------------

--- a/Code/Source/Common/Geometry/cv_geom_init.cxx
+++ b/Code/Source/Common/Geometry/cv_geom_init.cxx
@@ -46,6 +46,7 @@
 #include "cv_misc_utils.h"
 #include "cv_vtk_utils.h"
 #include "cv_solid_init.h"
+#include "vtkSmartPointer.h"
 
 // The following is needed for Windows
 #ifdef GetObject
@@ -4178,9 +4179,12 @@ int Geom_loftSolidWithNURBSCmd( ClientData clientData, Tcl_Interp *interp,
     return TCL_ERROR;
   }
 
+  vtkSmartPointer<vtkSVNURBSSurface> NURBSSurface =
+    vtkSmartPointer<vtkSVNURBSSurface>::New();
   if ( sys_geom_loft_solid_with_nurbs(srcs, numSrcs, uDegree, vDegree, uSpacing,
                                       vSpacing, uKnotSpanType, vKnotSpanType,
                                       uParametricSpanType, vParametricSpanType,
+                                      NURBSSurface,
 			                                (cvPolyData**)(&dst) ) != SV_OK ) {
     Tcl_SetResult( interp, "poly manipulation error", TCL_STATIC );
     delete dst;

--- a/Code/Source/Common/Geometry/cv_sys_geom.cxx
+++ b/Code/Source/Common/Geometry/cv_sys_geom.cxx
@@ -79,6 +79,7 @@
 #include "vtkSVLoopIntersectionPolyDataFilter.h"
 #include "vtkSVLoftNURBSSurface.h"
 #include "vtkSVMultiplePolyDataIntersectionFilter.h"
+#include "vtkSVNURBSSurface.h"
 
 #include "cv_polydatasolid_utils.h"
 
@@ -2402,6 +2403,7 @@ int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree,
                                    int vDegree, double uSpacing, double vSpacing,
                                    char *uKnotSpanType, char *vKnotSpanType,
                                    char *uParametricSpanType, char *vParametricSpanType,
+                                   vtkSVNURBSSurface *surface,
                                    cvPolyData **dst )
 {
   cvPolyData *result = NULL;
@@ -2433,6 +2435,7 @@ int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree,
   try {
     lofter->Update();
 
+    surface->DeepCopy(lofter->GetSurface());
 
     // The NURBS is a vtkPolyDataAlgorithm and thus, returns a PolyData
     // representation. To get the NURBS surface use GetSurface()

--- a/Code/Source/Common/Geometry/cv_sys_geom.cxx
+++ b/Code/Source/Common/Geometry/cv_sys_geom.cxx
@@ -2401,8 +2401,8 @@ int sys_geom_loft_solid( cvPolyData **srcs,int numSrcs,int useLinearSampleAlongL
 
 int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree,
                                    int vDegree, double uSpacing, double vSpacing,
-                                   char *uKnotSpanType, char *vKnotSpanType,
-                                   char *uParametricSpanType, char *vParametricSpanType,
+                                   const char *uKnotSpanType, const char *vKnotSpanType,
+                                   const char *uParametricSpanType, const char *vParametricSpanType,
                                    vtkSVNURBSSurface *surface,
                                    cvPolyData **dst )
 {
@@ -2434,6 +2434,10 @@ int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree,
   lofter->SetVParametricSpanType(vParametricSpanType);
   try {
     lofter->Update();
+    if (lofter->GetOutput() == NULL)
+      return SV_ERROR;
+    if (lofter->GetOutput()->GetNumberOfPoints() == 0)
+      return SV_ERROR;
 
     surface->DeepCopy(lofter->GetSurface());
 

--- a/Code/Source/Common/Geometry/cv_sys_geom.h
+++ b/Code/Source/Common/Geometry/cv_sys_geom.h
@@ -38,6 +38,7 @@
 #include "tcl.h"
 
 #include "cvPolyData.h"
+#include "vtkSVNURBSSurface.h"
 
 
 SV_EXPORT_SYSGEOM cvPolyData *sys_geom_DeepCopy( cvPolyData *src );
@@ -125,7 +126,7 @@ SV_EXPORT_SYSGEOM int sys_geom_loft_solid(cvPolyData **srcs,int numSrcs,int useL
 SV_EXPORT_SYSGEOM int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree, int vDegree,
                                                      double uSpacing, double vSpacing, char *uKnotSpanType,
                                                      char *vKnotSpanType, char *uParametricSpanType,
-                                                     char *vParametricSpanType, cvPolyData **dst);
+                                                     char *vParametricSpanType, vtkSVNURBSSurface *surface, cvPolyData **dst);
 
 SV_EXPORT_SYSGEOM int sys_geom_2DWindingNum( cvPolyData *pgn );
 

--- a/Code/Source/Common/Geometry/cv_sys_geom.h
+++ b/Code/Source/Common/Geometry/cv_sys_geom.h
@@ -124,9 +124,9 @@ SV_EXPORT_SYSGEOM int sys_geom_loft_solid(cvPolyData **srcs,int numSrcs,int useL
 		int numLinearPtsAlongLength,int numModes,int splineType,double bias,double tension, double continuity,cvPolyData **dst );
 
 SV_EXPORT_SYSGEOM int sys_geom_loft_solid_with_nurbs(cvPolyData **srcs, int numSrcs, int uDegree, int vDegree,
-                                                     double uSpacing, double vSpacing, char *uKnotSpanType,
-                                                     char *vKnotSpanType, char *uParametricSpanType,
-                                                     char *vParametricSpanType, vtkSVNURBSSurface *surface, cvPolyData **dst);
+                                                     double uSpacing, double vSpacing, const char *uKnotSpanType,
+                                                     const char *vKnotSpanType, const char *uParametricSpanType,
+                                                     const char *vParametricSpanType, vtkSVNURBSSurface *surface, cvPolyData **dst);
 
 SV_EXPORT_SYSGEOM int sys_geom_2DWindingNum( cvPolyData *pgn );
 

--- a/Code/Source/Model/OCCTSolidModel/cvOCCTSolidModel.cxx
+++ b/Code/Source/Model/OCCTSolidModel/cvOCCTSolidModel.cxx
@@ -1592,20 +1592,40 @@ int cvOCCTSolidModel::CreateBSplineSurface(double **CX,double **CY,double **CZ,
   }
 
   //Knot spans
+  fprintf(stdout,"U Knots son: ");
   TColStd_Array1OfReal uKCol(1,uKlen);
   for (int i=0;i<uKlen;i++)
+  {
+    fprintf(stdout,"%.4f ",uKnots[i]);
     uKCol.SetValue(i+1, uKnots[i]);
+  }
+  fprintf(stdout,"\n");
   TColStd_Array1OfReal vKCol(1,vKlen);
+  fprintf(stdout,"V Knots son: ");
   for (int i=0;i<vKlen;i++)
+  {
+    fprintf(stdout,"%.4f ",vKnots[i]);
     vKCol.SetValue(i+1, vKnots[i]);
+  }
+  fprintf(stdout,"\n");
 
   //Mult spans
+  fprintf(stdout,"U Mults son: ");
   TColStd_Array1OfInteger uMCol(1,uMlen);
   for (int i=0;i<uMlen;i++)
+  {
+    fprintf(stdout,"%.4f ",uMults[i]);
     uMCol.SetValue(i+1,(int) uMults[i]);
+  }
+  fprintf(stdout,"\n");
   TColStd_Array1OfInteger vMCol(1,vMlen);
+  fprintf(stdout,"V Mults son: ");
   for (int i=0;i<vMlen;i++)
+  {
+    fprintf(stdout,"%.4f ",vMults[i]);
     vMCol.SetValue(i+1,(int) vMults[i]);
+  }
+  fprintf(stdout,"\n");
 
   Standard_Real tol = 1.e-6;
   Handle(Geom_BSplineSurface) surface;

--- a/Code/Source/Model/OCCTSolidModel/cvOCCTSolidModel.cxx
+++ b/Code/Source/Model/OCCTSolidModel/cvOCCTSolidModel.cxx
@@ -1592,40 +1592,20 @@ int cvOCCTSolidModel::CreateBSplineSurface(double **CX,double **CY,double **CZ,
   }
 
   //Knot spans
-  fprintf(stdout,"U Knots son: ");
   TColStd_Array1OfReal uKCol(1,uKlen);
   for (int i=0;i<uKlen;i++)
-  {
-    fprintf(stdout,"%.4f ",uKnots[i]);
     uKCol.SetValue(i+1, uKnots[i]);
-  }
-  fprintf(stdout,"\n");
   TColStd_Array1OfReal vKCol(1,vKlen);
-  fprintf(stdout,"V Knots son: ");
   for (int i=0;i<vKlen;i++)
-  {
-    fprintf(stdout,"%.4f ",vKnots[i]);
     vKCol.SetValue(i+1, vKnots[i]);
-  }
-  fprintf(stdout,"\n");
 
   //Mult spans
-  fprintf(stdout,"U Mults son: ");
   TColStd_Array1OfInteger uMCol(1,uMlen);
   for (int i=0;i<uMlen;i++)
-  {
-    fprintf(stdout,"%.4f ",uMults[i]);
     uMCol.SetValue(i+1,(int) uMults[i]);
-  }
-  fprintf(stdout,"\n");
   TColStd_Array1OfInteger vMCol(1,vMlen);
-  fprintf(stdout,"V Mults son: ");
   for (int i=0;i<vMlen;i++)
-  {
-    fprintf(stdout,"%.4f ",vMults[i]);
     vMCol.SetValue(i+1,(int) vMults[i]);
-  }
-  fprintf(stdout,"\n");
 
   Standard_Real tol = 1.e-6;
   Handle(Geom_BSplineSurface) surface;

--- a/Code/Source/Model/OCCTSolidModel/cv_occt_init.cxx
+++ b/Code/Source/Model/OCCTSolidModel/cv_occt_init.cxx
@@ -254,9 +254,9 @@ PyObject* convertListsToOCCTObject(PyObject* self, PyObject* args)
       delete [] Yarr[i];
       delete [] Zarr[i];
     }
-    delete Xarr;
-    delete Yarr;
-    delete Zarr;
+    delete [] Xarr;
+    delete [] Yarr;
+    delete [] Zarr;
 
     delete [] uKarr;
     delete [] vKarr;
@@ -273,9 +273,9 @@ PyObject* convertListsToOCCTObject(PyObject* self, PyObject* args)
     delete [] Yarr[i];
     delete [] Zarr[i];
   }
-  delete Xarr;
-  delete Yarr;
-  delete Zarr;
+  delete [] Xarr;
+  delete [] Yarr;
+  delete [] Zarr;
 
   delete [] uKarr;
   delete [] vKarr;

--- a/Code/Source/Model/OCCTSolidModel/cv_occt_init.cxx
+++ b/Code/Source/Model/OCCTSolidModel/cv_occt_init.cxx
@@ -247,6 +247,21 @@ PyObject* convertListsToOCCTObject(PyObject* self, PyObject* args)
     uKarr,uKlen,vKarr,vKlen,uMarr,uMlen,vMarr,vMlen,p,q) != SV_OK)
   {
     //Set special python thingy
+    //Clean up
+    for (int i=0;i<Xlen1;i++)
+    {
+      delete [] Xarr[i];
+      delete [] Yarr[i];
+      delete [] Zarr[i];
+    }
+    delete Xarr;
+    delete Yarr;
+    delete Zarr;
+
+    delete [] uKarr;
+    delete [] vKarr;
+    delete [] uMarr;
+    delete [] vMarr;
     fprintf(stderr,"Conversion to BSpline surface didn't work\n");
     return NULL;
   }
@@ -258,9 +273,9 @@ PyObject* convertListsToOCCTObject(PyObject* self, PyObject* args)
     delete [] Yarr[i];
     delete [] Zarr[i];
   }
-  delete [] Xarr;
-  delete [] Yarr;
-  delete [] Zarr;
+  delete Xarr;
+  delete Yarr;
+  delete Zarr;
 
   delete [] uKarr;
   delete [] vKarr;

--- a/Code/Source/Modules/Model/svModelElement.h
+++ b/Code/Source/Modules/Model/svModelElement.h
@@ -112,6 +112,40 @@ public:
         }
     };
 
+    struct svNURBSLoftParam
+    {
+      int advancedLofting;
+      int uDegree;
+      int vDegree;
+      std::string uKnotSpanType;
+      std::string vKnotSpanType;
+      std::string uParametricSpanType;
+      std::string vParametricSpanType;
+
+      svNURBSLoftParam()
+        : advancedLofting(0),
+          uDegree(2),
+          vDegree(2),
+          uKnotSpanType("average"),
+          vKnotSpanType("average"),
+          uParametricSpanType("centripetal"),
+          vParametricSpanType("centripetal")
+      {
+      }
+      svNURBSLoftParam(const svNURBSLoftParam &src)
+        : advancedLofting(src.advancedLofting),
+          uDegree(src.uDegree),
+          vDegree(src.vDegree),
+          uKnotSpanType(src.uKnotSpanType),
+          vKnotSpanType(src.vKnotSpanType),
+          uParametricSpanType(src.uParametricSpanType),
+          vParametricSpanType(src.vParametricSpanType)
+      {
+      }
+
+    };
+
+
     svModelElement();
 
     svModelElement(const svModelElement &other);

--- a/Code/Source/Modules/Model/svModelUtils.cxx
+++ b/Code/Source/Modules/Model/svModelUtils.cxx
@@ -1164,14 +1164,14 @@ cvOCCTSolidModel* svModelUtils::CreateLoftSurfaceOCCT(std::vector<svContour*> co
     }
     else
     {
-      int uDegree = 2;
-      int vDegree = 2;
+      int uDegree = 3;
+      int vDegree = 3;
       double uSpacing = 0.8;
       double vSpacing = 0.8;
-      char uKnotSpanType[11]       = "average";
+      char uKnotSpanType[11]       = "derivative";
       char vKnotSpanType[8]        = "average";
       char uParametricSpanType[12] = "centripetal";
-      char vParametricSpanType[6]  = "chord";
+      char vParametricSpanType[12] = "centripetal";
       vtkNew(vtkSVNURBSSurface, NURBSSurface);
 
       cvPolyData *dst;
@@ -1251,13 +1251,14 @@ cvOCCTSolidModel* svModelUtils::CreateLoftSurfaceOCCT(std::vector<svContour*> co
       for (int i=0; i<vMlen; i++)
         vMarr[i] = VMultArray->GetTuple1(i);
 
+      // Flipping order!
       if (surf->CreateBSplineSurface(Xarr, Yarr, Zarr,
                                      Xlen1, Xlen2,
-                                     uKarr, uKlen,
                                      vKarr, vKlen,
-                                     uMarr, uMlen,
+                                     uKarr, uKlen,
                                      vMarr, vMlen,
-                                     uDegree, vDegree) != SV_OK )
+                                     uMarr, uMlen,
+                                     vDegree, uDegree) != SV_OK )
       {
           MITK_ERROR << "poly manipulation error ";
           for (int j=0; j<contourNumber; j++)

--- a/Code/Source/Modules/Model/svModelUtils.h
+++ b/Code/Source/Modules/Model/svModelUtils.h
@@ -23,17 +23,17 @@ class SVMODEL_EXPORT svModelUtils
 
 public:
 
-    static vtkPolyData* CreatePolyData(std::vector<svContourGroup*> groups, int numSamplingPts, int advancedLofting, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
+    static vtkPolyData* CreatePolyData(std::vector<svContourGroup*> groups, int numSamplingPts, svModelElement::svNURBSLoftParam *nurbsParam, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
 
-    static svModelElementPolyData* CreateModelElementPolyData(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int stats[], int advancedLofting, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
+    static svModelElementPolyData* CreateModelElementPolyData(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int stats[], svModelElement::svNURBSLoftParam *nurbsParam, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
 
     static vtkPolyData* CreatePolyDataByBlend(vtkPolyData* vpdsrc, int faceID1, int faceID2, double radius, svModelElementPolyData::svBlendParam* param);
 
     static svModelElementPolyData* CreateModelElementPolyDataByBlend(svModelElementPolyData* mepdsrc, std::vector<svModelElement::svBlendParamRadius*> blendRadii, svModelElementPolyData::svBlendParam* param);
 
-    static vtkPolyData* CreateLoftSurface(svContourGroup* contourGroup, int numSamplingPts,int advancedLofting, int addCaps, unsigned int t = 0,  svContourGroup::svLoftingParam* param = NULL);
+    static vtkPolyData* CreateLoftSurface(svContourGroup* contourGroup, int numSamplingPts,svModelElement::svNURBSLoftParam *nurbsParam, int addCaps, unsigned int t = 0,  svContourGroup::svLoftingParam* param = NULL);
 
-    static vtkPolyData* CreateLoftSurface(std::vector<svContour*> contourSet, int numSamplingPts,int advancedLofting, svContourGroup::svLoftingParam* param, int addCaps);
+    static vtkPolyData* CreateLoftSurface(std::vector<svContour*> contourSet, int numSamplingPts,svModelElement::svNURBSLoftParam *nurbsParam, svContourGroup::svLoftingParam* param, int addCaps);
 
     static vtkPolyData* CreateOrientOpenPolySolidVessel(vtkPolyData* inpd);
 
@@ -87,9 +87,9 @@ public:
 
 #ifdef SV_USE_OpenCASCADE_QT_GUI
 
-    static cvOCCTSolidModel* CreateLoftSurfaceOCCT(std::vector<svContour*> contourSet, std::string groupName, int numSamplingPts, int advancedLofting, int vecFlag, int addCaps);
+    static cvOCCTSolidModel* CreateLoftSurfaceOCCT(std::vector<svContour*> contourSet, std::string groupName, int numSamplingPts, svModelElement::svNURBSLoftParam *nurbsParam, int vecFlag, int addCaps);
 
-    static svModelElementOCCT* CreateModelElementOCCT(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int advancedLofting, double maxDist = 20.0, unsigned int t = 0);
+    static svModelElementOCCT* CreateModelElementOCCT(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, svModelElement::svNURBSLoftParam *nurbsParam, double maxDist = 20.0, unsigned int t = 0);
 
     static svModelElementOCCT* CreateModelElementOCCTByBlend(svModelElementOCCT* meocctsrc, std::vector<svModelElement::svBlendParamRadius*> blendRadii);
 

--- a/Code/Source/Modules/Model/svModelUtils.h
+++ b/Code/Source/Modules/Model/svModelUtils.h
@@ -87,9 +87,9 @@ public:
 
 #ifdef SV_USE_OpenCASCADE_QT_GUI
 
-    static cvOCCTSolidModel* CreateLoftSurfaceOCCT(std::vector<svContour*> contourSet, std::string groupName, int numSamplingPts, int vecFlag, int addCaps);
+    static cvOCCTSolidModel* CreateLoftSurfaceOCCT(std::vector<svContour*> contourSet, std::string groupName, int numSamplingPts, int advancedLofting, int vecFlag, int addCaps);
 
-    static svModelElementOCCT* CreateModelElementOCCT(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, double maxDist = 20.0, unsigned int t = 0);
+    static svModelElementOCCT* CreateModelElementOCCT(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int advancedLofting, double maxDist = 20.0, unsigned int t = 0);
 
     static svModelElementOCCT* CreateModelElementOCCTByBlend(svModelElementOCCT* meocctsrc, std::vector<svModelElement::svBlendParamRadius*> blendRadii);
 

--- a/Code/Source/Modules/Model/svModelUtils.h
+++ b/Code/Source/Modules/Model/svModelUtils.h
@@ -23,17 +23,17 @@ class SVMODEL_EXPORT svModelUtils
 
 public:
 
-    static vtkPolyData* CreatePolyData(std::vector<svContourGroup*> groups, int numSamplingPts, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
+    static vtkPolyData* CreatePolyData(std::vector<svContourGroup*> groups, int numSamplingPts, int advancedLofting, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
 
-    static svModelElementPolyData* CreateModelElementPolyData(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int stats[], unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
+    static svModelElementPolyData* CreateModelElementPolyData(std::vector<mitk::DataNode::Pointer> segNodes, int numSamplingPts, int stats[], int advancedLofting, unsigned int t = 0, int noInterOut = 1, double tol = 1e-6);
 
     static vtkPolyData* CreatePolyDataByBlend(vtkPolyData* vpdsrc, int faceID1, int faceID2, double radius, svModelElementPolyData::svBlendParam* param);
 
     static svModelElementPolyData* CreateModelElementPolyDataByBlend(svModelElementPolyData* mepdsrc, std::vector<svModelElement::svBlendParamRadius*> blendRadii, svModelElementPolyData::svBlendParam* param);
 
-    static vtkPolyData* CreateLoftSurface(svContourGroup* contourGroup, int numSamplingPts, int addCaps, unsigned int t = 0,  svContourGroup::svLoftingParam* param = NULL);
+    static vtkPolyData* CreateLoftSurface(svContourGroup* contourGroup, int numSamplingPts,int advancedLofting, int addCaps, unsigned int t = 0,  svContourGroup::svLoftingParam* param = NULL);
 
-    static vtkPolyData* CreateLoftSurface(std::vector<svContour*> contourSet, int numSamplingPts, svContourGroup::svLoftingParam* param, int addCaps);
+    static vtkPolyData* CreateLoftSurface(std::vector<svContour*> contourSet, int numSamplingPts,int advancedLofting, svContourGroup::svLoftingParam* param, int addCaps);
 
     static vtkPolyData* CreateOrientOpenPolySolidVessel(vtkPolyData* inpd);
 

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/files.cmake
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/files.cmake
@@ -13,6 +13,7 @@ set(INTERNAL_CPP_FILES
     svFaceListDelegate.cxx
     svModelFaceInfoExportAction.cxx
     svModelingPluginActivator.cxx
+    svModelPreferencePage.cxx
 )
 
 set(MOC_H_FILES
@@ -26,12 +27,14 @@ set(MOC_H_FILES
     src/internal/svFaceListDelegate.h
     src/internal/svModelFaceInfoExportAction.h
     src/internal/svModelingPluginActivator.h
+    src/internal/svModelPreferencePage.h
 )
 
 set(UI_FILES
     src/internal/svModelCreate.ui
     src/internal/svSegSelectionWidget.ui
     src/internal/svModelEdit.ui
+    src/internal/svModelPreferencePage.ui
 )
 
 set(CACHED_RESOURCE_FILES

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/plugin.xml
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/plugin.xml
@@ -14,6 +14,13 @@
       <contextMenuAction nodeDescriptorName="svModel" label="Extract Paths" icon="" class="svModelExtractPathsAction" />
       <contextMenuAction nodeDescriptorName="svModel" label="Export Solid Model" icon="" class="svModelLegacySaveAction" />
       <contextMenuAction nodeDescriptorName="svModel" label="Export Cap Info" icon="" class="svModelFaceInfoExportAction" />
+    </extension>
+
+  <extension point="org.blueberry.ui.preferencePages">
+    <page id="org.sv.gui.qt.ModelPreferencePage" name="SimVascular Model" class="svModelPreferencePage">
+      <keywordreference id="org.sv.gui.qt.ModelPreferencePageKeywords"></keywordreference>
+    </page>
   </extension>
+
 
 </plugin>

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
@@ -1475,7 +1475,8 @@ void svModelEdit::CreateModel()
     QString statusText="Model has been created.";
     if(m_ModelType=="PolyData"){
         int stats[2]={0};
-        newModelElement=svModelUtils::CreateModelElementPolyData(segNodes,numSampling,stats);
+        int advancedLofting = 1;
+        newModelElement=svModelUtils::CreateModelElementPolyData(segNodes,numSampling,stats,advancedLofting);
         if(newModelElement==NULL)
         {
             statusText="Failed to create PolyData model.";

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
@@ -1,6 +1,9 @@
 #include "svModelEdit.h"
 #include "ui_svModelEdit.h"
 
+#include <berryIPreferencesService.h>
+#include <berryPlatform.h>
+
 #include "svModelUtils.h"
 #include "svFaceListDelegate.h"
 #include "svPath.h"
@@ -1441,7 +1444,6 @@ void svModelEdit::CreateModel()
 {
     std::vector<std::string> segNames=m_SegSelectionWidget->GetUsedSegNames();
     int numSampling=m_SegSelectionWidget->GetNumSampling();
-    int advancedLofting = m_SegSelectionWidget->GetAdvancedLofting();
 
     mitk::NodePredicateDataType::Pointer isProjFolder = mitk::NodePredicateDataType::New("svProjectFolder");
     mitk::DataStorage::SetOfObjects::ConstPointer rs=GetDataStorage()->GetSubset(isProjFolder);
@@ -1473,13 +1475,33 @@ void svModelEdit::CreateModel()
     mitk::ProgressBar::GetInstance()->Progress();
     WaitCursorOn();
 
+    // Set up lofting parameters
+    svModelElement::svNURBSLoftParam *nurbsParam = new
+      svModelElement::svNURBSLoftParam();
+    nurbsParam->advancedLofting = m_SegSelectionWidget->GetAdvancedLofting();
+
+    // Get the lofting preferences!
+    berry::IPreferencesService *prefService = berry::Platform::GetPreferencesService();
+    Q_ASSERT(prefService);
+    berry::IPreferences::Pointer prefs = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
+
+    // Fill in rest of NURBS params with preferences
+    nurbsParam->uDegree = prefs->Get("NURBS Lofting U Degree", "2").toInt();
+    nurbsParam->vDegree = prefs->Get("NURBS Lofting V Degree", "2").toInt();
+    nurbsParam->uKnotSpanType = prefs->Get("NURBS Lofting U Knot Span Type", "derivative").trimmed().toStdString();
+    nurbsParam->vKnotSpanType = prefs->Get("NURBS Lofting V Knot Span Type", "average").trimmed().toStdString();
+    nurbsParam->uParametricSpanType = prefs->Get("NURBS Lofting U Parametric Span Type", "centripetal").trimmed().toStdString();
+    nurbsParam->vParametricSpanType = prefs->Get("NURBS Lofting V Parametric Span Type", "chord").trimmed().toStdString();
+
+    int created = 1;
     QString statusText="Model has been created.";
     if(m_ModelType=="PolyData"){
         int stats[2]={0};
-        newModelElement=svModelUtils::CreateModelElementPolyData(segNodes,numSampling,stats,advancedLofting);
+        newModelElement=svModelUtils::CreateModelElementPolyData(segNodes,numSampling,stats,nurbsParam);
         if(newModelElement==NULL)
         {
             statusText="Failed to create PolyData model.";
+            created = 0;
         }
         else
         {
@@ -1489,10 +1511,11 @@ void svModelEdit::CreateModel()
 #ifdef SV_USE_OpenCASCADE_QT_GUI
     else if(m_ModelType=="OpenCASCADE")
     {
-        newModelElement=svModelUtils::CreateModelElementOCCT(segNodes,numSampling,advancedLofting);
+        newModelElement=svModelUtils::CreateModelElementOCCT(segNodes,numSampling,nurbsParam);
         if(newModelElement==NULL)
         {
             statusText="Failed to create OpenCASCADE model.";
+            created = 0;
         }
     }
 #endif
@@ -1503,13 +1526,19 @@ void svModelEdit::CreateModel()
         if(newModelElement==NULL)
         {
             statusText="Failed to create Parasolid model.";
+            created = 0;
         }
     }
 #endif
-
+    delete nurbsParam;
     WaitCursorOff();
     mitk::ProgressBar::GetInstance()->Progress(2);
     mitk::StatusBar::GetInstance()->DisplayText(statusText.toStdString().c_str());
+    if (!created)
+    {
+      QMessageBox::warning(m_Parent,"Warning","Error creating model.");
+      return;
+    }
 
     if(newModelElement!=NULL)
     {
@@ -1603,6 +1632,8 @@ void svModelEdit::BlendModel()
         param->targetdecimation=ui->dsbDecimation->value();
 
         newModelElement=svModelUtils::CreateModelElementPolyDataByBlend(mepd, blendRadii, param);
+
+        delete param;
     }
 #ifdef SV_USE_OpenCASCADE_QT_GUI
     else if(m_ModelType=="OpenCASCADE")

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelEdit.cxx
@@ -1441,6 +1441,7 @@ void svModelEdit::CreateModel()
 {
     std::vector<std::string> segNames=m_SegSelectionWidget->GetUsedSegNames();
     int numSampling=m_SegSelectionWidget->GetNumSampling();
+    int advancedLofting = m_SegSelectionWidget->GetAdvancedLofting();
 
     mitk::NodePredicateDataType::Pointer isProjFolder = mitk::NodePredicateDataType::New("svProjectFolder");
     mitk::DataStorage::SetOfObjects::ConstPointer rs=GetDataStorage()->GetSubset(isProjFolder);
@@ -1475,7 +1476,6 @@ void svModelEdit::CreateModel()
     QString statusText="Model has been created.";
     if(m_ModelType=="PolyData"){
         int stats[2]={0};
-        int advancedLofting = 1;
         newModelElement=svModelUtils::CreateModelElementPolyData(segNodes,numSampling,stats,advancedLofting);
         if(newModelElement==NULL)
         {
@@ -1489,7 +1489,7 @@ void svModelEdit::CreateModel()
 #ifdef SV_USE_OpenCASCADE_QT_GUI
     else if(m_ModelType=="OpenCASCADE")
     {
-        newModelElement=svModelUtils::CreateModelElementOCCT(segNodes,numSampling);
+        newModelElement=svModelUtils::CreateModelElementOCCT(segNodes,numSampling,advancedLofting);
         if(newModelElement==NULL)
         {
             statusText="Failed to create OpenCASCADE model.";

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
@@ -1,0 +1,124 @@
+#include "svModelPreferencePage.h"
+#include "ui_svModelPreferencePage.h"
+
+#include <berryIPreferencesService.h>
+#include <berryPlatform.h>
+
+#include <mitkExceptionMacro.h>
+
+#include <QFileDialog>
+#include <QMessageBox>
+
+svModelPreferencePage::svModelPreferencePage()
+    : m_Preferences(nullptr)
+    , m_Ui(new Ui::svModelPreferencePage)
+    , m_Control(nullptr)
+{
+  // u knot span type
+  m_Ui->NURBSLoftingUKnotSpanType->clear();
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("equal");
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("average");
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("derivative");
+
+  // u parametric span type
+  m_Ui->NURBSLoftingUParametricSpanType->clear();
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("equal");
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("chord");
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("centripetal");
+
+  // v knot span type
+  m_Ui->NURBSLoftingVKnotSpanType->clear();
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("equal");
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("average");
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("derivative");
+
+  // v parametric span type
+  m_Ui->NURBSLoftingVParametricSpanType->clear();
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("equal");
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("chord");
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("centripetal");
+}
+
+svModelPreferencePage::~svModelPreferencePage()
+{
+}
+
+void svModelPreferencePage::CreateQtControl(QWidget* parent)
+{
+    m_Control = new QWidget(parent);
+
+    m_Ui->setupUi(m_Control);
+
+    berry::IPreferencesService* prefService = berry::Platform::GetPreferencesService();
+    Q_ASSERT(prefService);
+
+    m_Preferences = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
+
+    connect( m_Ui->NURBSLoftingUDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUDegree()) );
+    connect( m_Ui->NURBSLoftingVDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVDegree()) );
+    connect( m_Ui->NURBSLoftingUKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUKnotSpanType()) );
+    connect( m_Ui->NURBSLoftingVKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVKnotSpanType()) );
+    connect( m_Ui->NURBSLoftingUParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUParametricSpanType()) );
+    connect( m_Ui->NURBSLoftingVParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVParametricSpanType()) );
+
+    this->Update();
+}
+
+void svModelPreferencePage::SetNURBSLoftingUDegree()
+{
+  QString strNum=m_Ui->NURBSLoftingUDegreeEntry()->text().trimmed();
+  bool ok;
+  int num = strNum.toInt(&ok);
+
+  if (ok)
+  {
+    if (num < 1)
+    {
+      qmessagebox::warning(this,"value error","pleases give a positive integer.");
+      return;
+    }
+    m_NURBSLoftingUDegree = num;
+  }
+  else
+  {
+    QMessageBox::warning(this,"Format Error","Pleases give a correct format if you want to provide the number of sampling points.");
+    return;
+  }
+}
+
+QWidget* svModelPreferencePage::GetQtControl() const
+{
+    return m_Control;
+}
+
+void svModelPreferencePage::Init(berry::IWorkbench::Pointer)
+{
+}
+
+void svModelPreferencePage::PerformCancel()
+{
+}
+
+bool svModelPreferencePage::PerformOk()
+{
+    m_Preferences->Put("NURBS Lofting U Degree", m_NURBSLoftingUDegree);
+    m_Preferences->Put("NURBS Lofting V Degree", m_NURBSLoftingVDegree);
+
+    m_Preferences->Put("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType);
+    m_Preferences->Put("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType);
+
+    m_Preferences->Put("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType);
+    m_Preferences->Put("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType);
+
+    return true;
+}
+
+void svModelPreferencePage::Update()
+{
+  m_Ui->NURBSLoftingUDegree->setText(m_Preferences->Get("NURBS Lofting U Degree", m_NURBSLoftingUDegree, ""));
+  m_Ui->NURBSLoftingVDegree->setText(m_Preferences->Get("NURBS Lofting V Degree", m_NURBSLoftingVDegree, ""));
+  m_Ui->NURBSLoftingUKnotSpanType->setText(m_Preferences->Get("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType, ""));
+  m_Ui->NURBSLoftingVKnotSpanType->setText(m_Preferences->Get("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType, ""));
+  m_Ui->NURBSLoftingUParametricSpanType->setText(m_Preferences->Get("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType, ""));
+  m_Ui->NURBSLoftingVParametricSpanType->setText(m_Preferences->Get("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType, ""));
+}

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
@@ -14,29 +14,6 @@ svModelPreferencePage::svModelPreferencePage()
     , m_Ui(new Ui::svModelPreferencePage)
     , m_Control(nullptr)
 {
-  //// u knot span type
-  //m_Ui->NURBSLoftingUKnotSpanType->clear();
-  //m_Ui->NURBSLoftingUKnotSpanType->addItem("equal");
-  //m_Ui->NURBSLoftingUKnotSpanType->addItem("average");
-  //m_Ui->NURBSLoftingUKnotSpanType->addItem("derivative");
-
-  //// u parametric span type
-  //m_Ui->NURBSLoftingUParametricSpanType->clear();
-  //m_Ui->NURBSLoftingUParametricSpanType->addItem("equal");
-  //m_Ui->NURBSLoftingUParametricSpanType->addItem("chord");
-  //m_Ui->NURBSLoftingUParametricSpanType->addItem("centripetal");
-
-  //// v knot span type
-  //m_Ui->NURBSLoftingVKnotSpanType->clear();
-  //m_Ui->NURBSLoftingVKnotSpanType->addItem("equal");
-  //m_Ui->NURBSLoftingVKnotSpanType->addItem("average");
-  //m_Ui->NURBSLoftingVKnotSpanType->addItem("derivative");
-
-  //// v parametric span type
-  //m_Ui->NURBSLoftingVParametricSpanType->clear();
-  //m_Ui->NURBSLoftingVParametricSpanType->addItem("equal");
-  //m_Ui->NURBSLoftingVParametricSpanType->addItem("chord");
-  //m_Ui->NURBSLoftingVParametricSpanType->addItem("centripetal");
 }
 
 svModelPreferencePage::~svModelPreferencePage()
@@ -45,50 +22,45 @@ svModelPreferencePage::~svModelPreferencePage()
 
 void svModelPreferencePage::CreateQtControl(QWidget* parent)
 {
-    //m_Control = new QWidget(parent);
+  m_Control = new QWidget(parent);
 
-    //m_Ui->setupUi(m_Control);
+  m_Ui->setupUi(m_Control);
 
-    //berry::IPreferencesService* prefService = berry::Platform::GetPreferencesService();
-    //Q_ASSERT(prefService);
+  berry::IPreferencesService* prefService = berry::Platform::GetPreferencesService();
+  Q_ASSERT(prefService);
 
-    //m_Preferences = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
+  m_Preferences = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
 
-    //connect( m_Ui->NURBSLoftingUDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUDegree()) );
-    //connect( m_Ui->NURBSLoftingVDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVDegree()) );
-    //connect( m_Ui->NURBSLoftingUKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUKnotSpanType()) );
-    //connect( m_Ui->NURBSLoftingVKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVKnotSpanType()) );
-    //connect( m_Ui->NURBSLoftingUParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUParametricSpanType()) );
-    //connect( m_Ui->NURBSLoftingVParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVParametricSpanType()) );
+  // u knot span type
+  m_Ui->NURBSLoftingUKnotSpanType->clear();
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("equal");
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("average");
+  m_Ui->NURBSLoftingUKnotSpanType->addItem("derivative");
 
-    //this->Update();
+  // u parametric span type
+  m_Ui->NURBSLoftingUParametricSpanType->clear();
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("equal");
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("chord");
+  m_Ui->NURBSLoftingUParametricSpanType->addItem("centripetal");
+
+  // v knot span type
+  m_Ui->NURBSLoftingVKnotSpanType->clear();
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("equal");
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("average");
+  m_Ui->NURBSLoftingVKnotSpanType->addItem("derivative");
+
+  // v parametric span type
+  m_Ui->NURBSLoftingVParametricSpanType->clear();
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("equal");
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("chord");
+  m_Ui->NURBSLoftingVParametricSpanType->addItem("centripetal");
+
+  this->Update();
 }
-
-//void svModelPreferencePage::SetNURBSLoftingUDegree()
-//{
-  //QString strNum=m_Ui->NURBSLoftingUDegreeEntry()->text().trimmed();
-  //bool ok;
-  //int num = strNum.toInt(&ok);
-
-  //if (ok)
-  //{
-  //  if (num < 1)
-  //  {
-  //    qmessagebox::warning(this,"value error","pleases give a positive integer.");
-  //    return;
-  //  }
-  //  m_NURBSLoftingUDegree = num;
-  //}
-  //else
-  //{
-  //  QMessageBox::warning(this,"Format Error","Pleases give a correct format if you want to provide the number of sampling points.");
-  //  return;
-  //}
-//}
 
 QWidget* svModelPreferencePage::GetQtControl() const
 {
-    //return m_Control;
+  return m_Control;
 }
 
 void svModelPreferencePage::Init(berry::IWorkbench::Pointer)
@@ -101,24 +73,62 @@ void svModelPreferencePage::PerformCancel()
 
 bool svModelPreferencePage::PerformOk()
 {
-    //m_Preferences->Put("NURBS Lofting U Degree", m_NURBSLoftingUDegree);
-    //m_Preferences->Put("NURBS Lofting V Degree", m_NURBSLoftingVDegree);
+  QString NURBSLoftingUKnotSpanType = m_Ui->NURBSLoftingUKnotSpanType->currentText().trimmed();
+  QString NURBSLoftingVKnotSpanType = m_Ui->NURBSLoftingVKnotSpanType->currentText().trimmed();
+  QString NURBSLoftingUParametricSpanType = m_Ui->NURBSLoftingUParametricSpanType->currentText().trimmed();
+  QString NURBSLoftingVParametricSpanType = m_Ui->NURBSLoftingVParametricSpanType->currentText().trimmed();
 
-    //m_Preferences->Put("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType);
-    //m_Preferences->Put("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType);
+  m_Preferences->Put("NURBS Lofting U Knot Span Type", NURBSLoftingUKnotSpanType);
+  m_Preferences->Put("NURBS Lofting V Knot Span Type", NURBSLoftingVKnotSpanType);
 
-    //m_Preferences->Put("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType);
-    //m_Preferences->Put("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType);
+  m_Preferences->Put("NURBS Lofting U Parametric Span Type", NURBSLoftingUParametricSpanType);
+  m_Preferences->Put("NURBS Lofting V Parametric Span Type", NURBSLoftingVParametricSpanType);
 
-    //return true;
+  QString NURBSLoftingUDegree = m_Ui->NURBSLoftingUDegree->text().trimmed();
+  bool ok;
+  int uDeg = NURBSLoftingUDegree.toInt(&ok);
+
+  if (!ok || uDeg < 1)
+  {
+    QMessageBox::warning(m_Control,"value error","please give a positive integer for u degree.");
+    return false;
+  }
+
+  QString NURBSLoftingVDegree = m_Ui->NURBSLoftingVDegree->text().trimmed();
+  int vDeg = NURBSLoftingVDegree.toInt(&ok);
+  if (!ok || vDeg < 1)
+  {
+    QMessageBox::warning(m_Control,"value error","please give a positive integer for v degree.");
+    return false;
+  }
+
+  m_Preferences->Put("NURBS Lofting U Degree", NURBSLoftingUDegree);
+  m_Preferences->Put("NURBS Lofting V Degree", NURBSLoftingVDegree);
+
+  return true;
 }
 
 void svModelPreferencePage::Update()
 {
-  //m_Ui->NURBSLoftingUDegree->setText(m_Preferences->Get("NURBS Lofting U Degree", m_NURBSLoftingUDegree, ""));
-  //m_Ui->NURBSLoftingVDegree->setText(m_Preferences->Get("NURBS Lofting V Degree", m_NURBSLoftingVDegree, ""));
-  //m_Ui->NURBSLoftingUKnotSpanType->setText(m_Preferences->Get("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType, ""));
-  //m_Ui->NURBSLoftingVKnotSpanType->setText(m_Preferences->Get("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType, ""));
-  //m_Ui->NURBSLoftingUParametricSpanType->setText(m_Preferences->Get("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType, ""));
-  //m_Ui->NURBSLoftingVParametricSpanType->setText(m_Preferences->Get("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType, ""));
+  m_Ui->NURBSLoftingUDegree->setText(
+    m_Preferences->Get("NURBS Lofting U Degree", "2"));
+
+  m_Ui->NURBSLoftingVDegree->setText(
+    m_Preferences->Get("NURBS Lofting V Degree", "2"));
+
+  m_Ui->NURBSLoftingUKnotSpanType->setCurrentIndex(
+    m_Ui->NURBSLoftingUKnotSpanType->findText(
+    m_Preferences->Get("NURBS Lofting U Knot Span Type", "derivative")));
+
+  m_Ui->NURBSLoftingVKnotSpanType->setCurrentIndex(
+    m_Ui->NURBSLoftingVKnotSpanType->findText(
+    m_Preferences->Get("NURBS Lofting V Knot Span Type", "average")));
+
+  m_Ui->NURBSLoftingUParametricSpanType->setCurrentIndex(
+    m_Ui->NURBSLoftingUParametricSpanType->findText(
+    m_Preferences->Get("NURBS Lofting U Parametric Span Type", "centripetal")));
+
+  m_Ui->NURBSLoftingVParametricSpanType->setCurrentIndex(
+    m_Ui->NURBSLoftingVParametricSpanType->findText(
+    m_Preferences->Get("NURBS Lofting V Parametric Span Type", "chord")));
 }

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.cxx
@@ -14,29 +14,29 @@ svModelPreferencePage::svModelPreferencePage()
     , m_Ui(new Ui::svModelPreferencePage)
     , m_Control(nullptr)
 {
-  // u knot span type
-  m_Ui->NURBSLoftingUKnotSpanType->clear();
-  m_Ui->NURBSLoftingUKnotSpanType->addItem("equal");
-  m_Ui->NURBSLoftingUKnotSpanType->addItem("average");
-  m_Ui->NURBSLoftingUKnotSpanType->addItem("derivative");
+  //// u knot span type
+  //m_Ui->NURBSLoftingUKnotSpanType->clear();
+  //m_Ui->NURBSLoftingUKnotSpanType->addItem("equal");
+  //m_Ui->NURBSLoftingUKnotSpanType->addItem("average");
+  //m_Ui->NURBSLoftingUKnotSpanType->addItem("derivative");
 
-  // u parametric span type
-  m_Ui->NURBSLoftingUParametricSpanType->clear();
-  m_Ui->NURBSLoftingUParametricSpanType->addItem("equal");
-  m_Ui->NURBSLoftingUParametricSpanType->addItem("chord");
-  m_Ui->NURBSLoftingUParametricSpanType->addItem("centripetal");
+  //// u parametric span type
+  //m_Ui->NURBSLoftingUParametricSpanType->clear();
+  //m_Ui->NURBSLoftingUParametricSpanType->addItem("equal");
+  //m_Ui->NURBSLoftingUParametricSpanType->addItem("chord");
+  //m_Ui->NURBSLoftingUParametricSpanType->addItem("centripetal");
 
-  // v knot span type
-  m_Ui->NURBSLoftingVKnotSpanType->clear();
-  m_Ui->NURBSLoftingVKnotSpanType->addItem("equal");
-  m_Ui->NURBSLoftingVKnotSpanType->addItem("average");
-  m_Ui->NURBSLoftingVKnotSpanType->addItem("derivative");
+  //// v knot span type
+  //m_Ui->NURBSLoftingVKnotSpanType->clear();
+  //m_Ui->NURBSLoftingVKnotSpanType->addItem("equal");
+  //m_Ui->NURBSLoftingVKnotSpanType->addItem("average");
+  //m_Ui->NURBSLoftingVKnotSpanType->addItem("derivative");
 
-  // v parametric span type
-  m_Ui->NURBSLoftingVParametricSpanType->clear();
-  m_Ui->NURBSLoftingVParametricSpanType->addItem("equal");
-  m_Ui->NURBSLoftingVParametricSpanType->addItem("chord");
-  m_Ui->NURBSLoftingVParametricSpanType->addItem("centripetal");
+  //// v parametric span type
+  //m_Ui->NURBSLoftingVParametricSpanType->clear();
+  //m_Ui->NURBSLoftingVParametricSpanType->addItem("equal");
+  //m_Ui->NURBSLoftingVParametricSpanType->addItem("chord");
+  //m_Ui->NURBSLoftingVParametricSpanType->addItem("centripetal");
 }
 
 svModelPreferencePage::~svModelPreferencePage()
@@ -45,50 +45,50 @@ svModelPreferencePage::~svModelPreferencePage()
 
 void svModelPreferencePage::CreateQtControl(QWidget* parent)
 {
-    m_Control = new QWidget(parent);
+    //m_Control = new QWidget(parent);
 
-    m_Ui->setupUi(m_Control);
+    //m_Ui->setupUi(m_Control);
 
-    berry::IPreferencesService* prefService = berry::Platform::GetPreferencesService();
-    Q_ASSERT(prefService);
+    //berry::IPreferencesService* prefService = berry::Platform::GetPreferencesService();
+    //Q_ASSERT(prefService);
 
-    m_Preferences = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
+    //m_Preferences = prefService->GetSystemPreferences()->Node("/org.sv.views.modeling");
 
-    connect( m_Ui->NURBSLoftingUDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUDegree()) );
-    connect( m_Ui->NURBSLoftingVDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVDegree()) );
-    connect( m_Ui->NURBSLoftingUKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUKnotSpanType()) );
-    connect( m_Ui->NURBSLoftingVKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVKnotSpanType()) );
-    connect( m_Ui->NURBSLoftingUParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUParametricSpanType()) );
-    connect( m_Ui->NURBSLoftingVParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVParametricSpanType()) );
+    //connect( m_Ui->NURBSLoftingUDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUDegree()) );
+    //connect( m_Ui->NURBSLoftingVDegree, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVDegree()) );
+    //connect( m_Ui->NURBSLoftingUKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUKnotSpanType()) );
+    //connect( m_Ui->NURBSLoftingVKnotSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVKnotSpanType()) );
+    //connect( m_Ui->NURBSLoftingUParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingUParametricSpanType()) );
+    //connect( m_Ui->NURBSLoftingVParametricSpanType, SIGNAL(clicked()), this, SLOT(SetNURBSLoftingVParametricSpanType()) );
 
-    this->Update();
+    //this->Update();
 }
 
-void svModelPreferencePage::SetNURBSLoftingUDegree()
-{
-  QString strNum=m_Ui->NURBSLoftingUDegreeEntry()->text().trimmed();
-  bool ok;
-  int num = strNum.toInt(&ok);
+//void svModelPreferencePage::SetNURBSLoftingUDegree()
+//{
+  //QString strNum=m_Ui->NURBSLoftingUDegreeEntry()->text().trimmed();
+  //bool ok;
+  //int num = strNum.toInt(&ok);
 
-  if (ok)
-  {
-    if (num < 1)
-    {
-      qmessagebox::warning(this,"value error","pleases give a positive integer.");
-      return;
-    }
-    m_NURBSLoftingUDegree = num;
-  }
-  else
-  {
-    QMessageBox::warning(this,"Format Error","Pleases give a correct format if you want to provide the number of sampling points.");
-    return;
-  }
-}
+  //if (ok)
+  //{
+  //  if (num < 1)
+  //  {
+  //    qmessagebox::warning(this,"value error","pleases give a positive integer.");
+  //    return;
+  //  }
+  //  m_NURBSLoftingUDegree = num;
+  //}
+  //else
+  //{
+  //  QMessageBox::warning(this,"Format Error","Pleases give a correct format if you want to provide the number of sampling points.");
+  //  return;
+  //}
+//}
 
 QWidget* svModelPreferencePage::GetQtControl() const
 {
-    return m_Control;
+    //return m_Control;
 }
 
 void svModelPreferencePage::Init(berry::IWorkbench::Pointer)
@@ -101,24 +101,24 @@ void svModelPreferencePage::PerformCancel()
 
 bool svModelPreferencePage::PerformOk()
 {
-    m_Preferences->Put("NURBS Lofting U Degree", m_NURBSLoftingUDegree);
-    m_Preferences->Put("NURBS Lofting V Degree", m_NURBSLoftingVDegree);
+    //m_Preferences->Put("NURBS Lofting U Degree", m_NURBSLoftingUDegree);
+    //m_Preferences->Put("NURBS Lofting V Degree", m_NURBSLoftingVDegree);
 
-    m_Preferences->Put("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType);
-    m_Preferences->Put("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType);
+    //m_Preferences->Put("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType);
+    //m_Preferences->Put("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType);
 
-    m_Preferences->Put("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType);
-    m_Preferences->Put("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType);
+    //m_Preferences->Put("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType);
+    //m_Preferences->Put("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType);
 
-    return true;
+    //return true;
 }
 
 void svModelPreferencePage::Update()
 {
-  m_Ui->NURBSLoftingUDegree->setText(m_Preferences->Get("NURBS Lofting U Degree", m_NURBSLoftingUDegree, ""));
-  m_Ui->NURBSLoftingVDegree->setText(m_Preferences->Get("NURBS Lofting V Degree", m_NURBSLoftingVDegree, ""));
-  m_Ui->NURBSLoftingUKnotSpanType->setText(m_Preferences->Get("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType, ""));
-  m_Ui->NURBSLoftingVKnotSpanType->setText(m_Preferences->Get("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType, ""));
-  m_Ui->NURBSLoftingUParametricSpanType->setText(m_Preferences->Get("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType, ""));
-  m_Ui->NURBSLoftingVParametricSpanType->setText(m_Preferences->Get("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType, ""));
+  //m_Ui->NURBSLoftingUDegree->setText(m_Preferences->Get("NURBS Lofting U Degree", m_NURBSLoftingUDegree, ""));
+  //m_Ui->NURBSLoftingVDegree->setText(m_Preferences->Get("NURBS Lofting V Degree", m_NURBSLoftingVDegree, ""));
+  //m_Ui->NURBSLoftingUKnotSpanType->setText(m_Preferences->Get("NURBS Lofting U Knot Span Type", m_NURBSLoftingUKnotSpanType, ""));
+  //m_Ui->NURBSLoftingVKnotSpanType->setText(m_Preferences->Get("NURBS Lofting V Knot Span Type", m_NURBSLoftingVKnotSpanType, ""));
+  //m_Ui->NURBSLoftingUParametricSpanType->setText(m_Preferences->Get("NURBS Lofting U Parametric Span Type", m_NURBSLoftingUParametricSpanType, ""));
+  //m_Ui->NURBSLoftingVParametricSpanType->setText(m_Preferences->Get("NURBS Lofting V Parametric Span Type", m_NURBSLoftingVParametricSpanType, ""));
 }

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
@@ -24,14 +24,6 @@ public:
     bool PerformOk() override;
     void Update() override;
 
-private slots:
-  //void SetNURBSLoftingUDegree();
-  //void SetNURBSLoftingVDegree();
-  //void SetNURBSLoftingUKnotSpanType();
-  //void SetNURBSLoftingVKnotSpanType();
-  //void SetNURBSLoftingUParametricSpanType();
-  //void SetNURBSLoftingVParametricSpanType();
-
 private:
   berry::IPreferences::Pointer m_Preferences;
   QScopedPointer<Ui::svModelPreferencePage> m_Ui;

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
@@ -1,0 +1,42 @@
+#ifndef SVMODELPREFERENCEPAGE_H
+#define SVMODELPREFERENCEPAGE_H
+
+#include <berryIPreferences.h>
+#include <berryIQtPreferencePage.h>
+
+namespace Ui {
+class svModelPreferencePage;
+}
+
+class svModelPreferencePage : public QObject, public berry::IQtPreferencePage
+{
+    Q_OBJECT
+    Q_INTERFACES(berry::IPreferencePage)
+
+public:
+    svModelPreferencePage();
+    ~svModelPreferencePage();
+
+    void CreateQtControl(QWidget* parent) override;
+    QWidget* GetQtControl() const override;
+    void Init(berry::IWorkbench::Pointer) override;
+    void PerformCancel() override;
+    bool PerformOk() override;
+    void Update() override;
+
+private slots:
+  void SetNURBSLoftingUDegree();
+  void SetNURBSLoftingVDegree();
+  void SetNURBSLoftingUKnotSpanType();
+  void SetNURBSLoftingVKnotSpanType();
+  void SetNURBSLoftingUParametricSpanType();
+  void SetNURBSLoftingVParametricSpanType();
+
+private:
+  berry::IPreferences::Pointer m_Preferences;
+  QScopedPointer<Ui::svModelPreferencePage> m_Ui;
+  QWidget* m_Control;
+
+};
+
+#endif // SVSIMULATIONPREFERENCEPAGE_H

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.h
@@ -25,12 +25,12 @@ public:
     void Update() override;
 
 private slots:
-  void SetNURBSLoftingUDegree();
-  void SetNURBSLoftingVDegree();
-  void SetNURBSLoftingUKnotSpanType();
-  void SetNURBSLoftingVKnotSpanType();
-  void SetNURBSLoftingUParametricSpanType();
-  void SetNURBSLoftingVParametricSpanType();
+  //void SetNURBSLoftingUDegree();
+  //void SetNURBSLoftingVDegree();
+  //void SetNURBSLoftingUKnotSpanType();
+  //void SetNURBSLoftingVKnotSpanType();
+  //void SetNURBSLoftingUParametricSpanType();
+  //void SetNURBSLoftingVParametricSpanType();
 
 private:
   berry::IPreferences::Pointer m_Preferences;
@@ -39,4 +39,4 @@ private:
 
 };
 
-#endif // SVSIMULATIONPREFERENCEPAGE_H
+#endif // SVMODELPREFERENCEPAGE_H

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>svSimulationPreferencePage</class>
- <widget class="QWidget" name="svSimulationPreferencePage">
+ <class>svModelPreferencePage</class>
+ <widget class="QWidget" name="svModelPreferencePage">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -58,13 +58,16 @@
                </size>
               </property>
               <property name="text">
-               <string>2</string>
+               <string>3</string>
               </property>
               <property name="frame">
                <bool>true</bool>
               </property>
               <property name="dragEnabled">
                <bool>false</bool>
+              </property>
+              <property name="placeholderText">
+               <string>3</string>
               </property>
              </widget>
             </item>
@@ -104,10 +107,6 @@
           </widget>
          </item>
         </layout>
-        <zorder>label_3</zorder>
-        <zorder>widget_2</zorder>
-        <zorder>widget</zorder>
-        <zorder>widget_5</zorder>
        </widget>
       </item>
       <item>
@@ -135,7 +134,10 @@
                </size>
               </property>
               <property name="text">
-               <string>2</string>
+               <string>3</string>
+              </property>
+              <property name="placeholderText">
+               <string>3</string>
               </property>
              </widget>
             </item>
@@ -179,11 +181,6 @@
           </widget>
          </item>
         </layout>
-        <zorder>widget_3</zorder>
-        <zorder>label_4</zorder>
-        <zorder>widget_3</zorder>
-        <zorder>widget_4</zorder>
-        <zorder>widget_6</zorder>
        </widget>
       </item>
      </layout>

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelPreferencePage.ui
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>svSimulationPreferencePage</class>
+ <widget class="QWidget" name="svSimulationPreferencePage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>553</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QFrame" name="frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="label">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>NURBS Lofting Options:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox">
+        <property name="title">
+         <string>Longitudinal Direction:</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QWidget" name="widget_2" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Degree:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="NURBSLoftingUDegree">
+              <property name="maximumSize">
+               <size>
+                <width>30</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>2</string>
+              </property>
+              <property name="frame">
+               <bool>true</bool>
+              </property>
+              <property name="dragEnabled">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Knot Span Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="NURBSLoftingUKnotSpanType"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget_5" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <widget class="QLabel" name="label_6">
+              <property name="text">
+               <string>Parametric Span Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="NURBSLoftingUParametricSpanType"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+        <zorder>label_3</zorder>
+        <zorder>widget_2</zorder>
+        <zorder>widget</zorder>
+        <zorder>widget_5</zorder>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBox_2">
+        <property name="title">
+         <string>Circumferential Direction:</string>
+        </property>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QWidget" name="widget_3" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="text">
+               <string>Degree:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="NURBSLoftingVDegree">
+              <property name="maximumSize">
+               <size>
+                <width>30</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>2</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget_4" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="label_5">
+              <property name="text">
+               <string>Knot Span Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="NURBSLoftingVKnotSpanType">
+              <property name="editable">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget_6" native="true">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Parametric Span Type:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="NURBSLoftingVParametricSpanType"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+        <zorder>widget_3</zorder>
+        <zorder>label_4</zorder>
+        <zorder>widget_3</zorder>
+        <zorder>widget_4</zorder>
+        <zorder>widget_6</zorder>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelingPluginActivator.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svModelingPluginActivator.cxx
@@ -1,5 +1,6 @@
 #include "svModelingPluginActivator.h"
 #include "svModelCreateAction.h"
+#include "svModelPreferencePage.h"
 #include "svModelLegacyLoadAction.h"
 #include "svModelLegacySaveAction.h"
 #include "svModelExtractPathsAction.h"
@@ -15,6 +16,7 @@ void svModelingPluginActivator::start(ctkPluginContext* context)
 //    m_Context = context;
 
     BERRY_REGISTER_EXTENSION_CLASS(svModelCreateAction, context)
+    BERRY_REGISTER_EXTENSION_CLASS(svModelPreferencePage, context)
     BERRY_REGISTER_EXTENSION_CLASS(svModelLegacyLoadAction, context)
     BERRY_REGISTER_EXTENSION_CLASS(svModelLegacySaveAction, context)
     BERRY_REGISTER_EXTENSION_CLASS(svModelExtractPathsAction, context)

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.cxx
@@ -8,6 +8,7 @@ svSegSelectionWidget::svSegSelectionWidget(QWidget *parent)
     , ui(new Ui::svSegSelectionWidget)
     , m_TableModel(NULL)
     , m_NumSampling(0)
+    , m_AdvancedLofting(0)
     , m_ModelElement(NULL)
     , m_ModelType("")
 {
@@ -130,9 +131,16 @@ int svSegSelectionWidget::GetNumSampling()
     return m_NumSampling;
 }
 
+int svSegSelectionWidget::GetAdvancedLofting()
+{
+    return m_AdvancedLofting;
+}
+
+
 void svSegSelectionWidget::Confirm()
 {
     QString strNum=ui->lineEditNumSampling->text().trimmed();
+    m_AdvancedLofting = ui->advancedLoftingCheckBox->isChecked();
 
     if(strNum=="")
     {

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.h
@@ -26,6 +26,7 @@ public:
     std::vector<std::string> GetUsedSegNames();
 
     int GetNumSampling();
+    int GetAdvancedLofting();
 
 public slots:
 
@@ -50,6 +51,8 @@ private:
     Ui::svSegSelectionWidget *ui;
 
     int m_NumSampling;
+
+    int m_AdvancedLofting;
 
     svModelElement* m_ModelElement;
 

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
@@ -99,7 +99,14 @@
        </widget>
       </item>
       <item>
-       <widget class="QLineEdit" name="lineEditNumSampling"/>
+       <widget class="QLineEdit" name="lineEditNumSampling">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string/>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>483</width>
-    <height>649</height>
+    <height>711</height>
    </rect>
   </property>
   <property name="contextMenuPolicy">
@@ -105,6 +105,22 @@
     </widget>
    </item>
    <item>
+    <widget class="QWidget" name="widget_4" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <widget class="QCheckBox" name="advancedLoftingCheckBox">
+        <property name="text">
+         <string>Advanced Lofting</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QWidget" name="widget_2" native="true">
      <layout class="QGridLayout" name="gridLayout">
       <property name="leftMargin">
@@ -134,6 +150,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tableView</tabstop>
+  <tabstop>lineEditNumSampling</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.modeling/src/internal/svSegSelectionWidget.ui
@@ -53,7 +53,7 @@
       <item>
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Choose Segmentions for Model Creation:</string>
+         <string>Choose Segmentations for Model Creation:</string>
         </property>
        </widget>
       </item>

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVControlGrid.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVControlGrid.cxx
@@ -217,12 +217,12 @@ int vtkSVControlGrid::GetPointId(const int i, const int j, const int k, int &ptI
   int extent[6];
   this->GetExtent(extent);
 
-  fprintf(stdout,"Extents: %d %d %d %d %d %d\n", extent[0],
-                                                    extent[1],
-                                                    extent[2],
-                                                    extent[3],
-                                                    extent[4],
-                                                    extent[5]);
+  //fprintf(stdout,"Extents: %d %d %d %d %d %d\n", extent[0],
+  //                                                  extent[1],
+  //                                                  extent[2],
+  //                                                  extent[3],
+  //                                                  extent[4],
+  //                                                  extent[5]);
   if(i < extent[0] || i > extent[1] ||
      j < extent[2] || j > extent[3] ||
      k < extent[4] || k > extent[5])

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSCurve.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSCurve.cxx
@@ -86,6 +86,25 @@ vtkSVNURBSCurve::~vtkSVNURBSCurve()
 }
 
 // ----------------------
+// DeepCopy
+// ----------------------
+void vtkSVNURBSCurve::DeepCopy(vtkSVNURBSCurve *src)
+{
+  this->Superclass::DeepCopy(src);
+
+  this->SetNumberOfControlPoints(src->GetNumberOfControlPoints());
+  this->SetNumberOfKnotPoints(src->GetNumberOfKnotPoints());
+  this->SetDegree(src->GetDegree());
+
+  this->ControlPointGrid->DeepCopy(src->GetControlPointGrid());
+  this->KnotVector->DeepCopy(src->GetKnotVector());
+  this->Weights->DeepCopy(src->GetWeights());
+
+  this->CurveRepresentation->DeepCopy(src->GetCurveRepresentation());
+}
+
+
+// ----------------------
 // PrintSelf
 // ----------------------
 void vtkSVNURBSCurve::PrintSelf(ostream& os, vtkIndent indent)
@@ -146,21 +165,6 @@ void vtkSVNURBSCurve::SetControlPoints(vtkPoints *points1d)
 
   // Update number of control points
   this->NumberOfControlPoints = nCon;
-}
-
-// ----------------------
-// SetKnotVector
-// ----------------------
-void vtkSVNURBSCurve::SetKnotVector(vtkDoubleArray *knotVector)
-{
-  // Get number of knots
-  int nKnot = knotVector->GetNumberOfTuples();
-
-  // Copy knots
-  this->KnotVector->DeepCopy(knotVector);
-
-  // Update number of knots
-  this->NumberOfKnotPoints = nKnot;
 }
 
 // ----------------------
@@ -297,5 +301,14 @@ int vtkSVNURBSCurve::GetStructuredGridConnectivity(const int numPoints, vtkCellA
     connectivity->InsertNextCell(ptIds);
   }
 
+  return SV_OK;
+}
+
+// ----------------------
+// GetMultiplicity
+// ----------------------
+int vtkSVNURBSCurve::GetMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots)
+{
+  vtkSVNURBSUtils::GetMultiplicity(this->KnotVector, multiplicity, singleKnots);
   return SV_OK;
 }

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSCurve.h
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSCurve.h
@@ -76,18 +76,33 @@ public:
   //@}
 
   //@{
+  /// \brief Get and set the degree
+  vtkGetMacro(Degree, int);
+  vtkSetMacro(Degree, int);
+  //@}
+
+  //@{
   /// \brief Get and set the control point grid
   vtkGetObjectMacro(ControlPointGrid, vtkSVControlGrid);
+  vtkSetObjectMacro(ControlPointGrid, vtkSVControlGrid);
   //@}
 
   //@{
   /// \brief Get and set the knot vector object
   vtkGetObjectMacro(KnotVector, vtkDoubleArray);
+  vtkSetObjectMacro(KnotVector, vtkDoubleArray);
   //@}
 
   //@{
-  // Get the PolyData Representation
+  /// \brief Get and set the weights
+  vtkGetObjectMacro(Weights, vtkDoubleArray);
+  vtkSetObjectMacro(Weights, vtkDoubleArray);
+  //@}
+
+  //@{
+  // \brief Get and set the PolyData Representation
   vtkGetObjectMacro(CurveRepresentation, vtkPolyData);
+  vtkSetObjectMacro(CurveRepresentation, vtkPolyData);
   //@}
 
   // Initialize
@@ -103,17 +118,10 @@ public:
    *  \param connectivity empty cell array to be filled with a structured grid connectivity. */
   int GetStructuredGridConnectivity(const int numPoints, vtkCellArray *connectivity);
 
-  //Functions to set control points/knots/etc.
-  void SetControlPointGrid(vtkSVControlGrid *controlPoints) {} /**< \brief Unimplemented */
-
   /** \brief Set the control points using a point set. */
   void SetControlPoints(vtkPoints *points1d);
 
   //void SetControlPoints(vtkDenseArray<double[3]> *points2d) {} /**< \brief Unimplemented */
-
-  /** \brief Set the knot vector with a double array. */
-  void SetKnotVector(vtkDoubleArray *knotVector);
-
   //Functions to manipulate the geometry
   void UpdateCurve() {} /**< \brief Unimplemented */
   int IncreaseDegree(const int degree) {return 0;} /**< \brief Unimplemented */
@@ -142,12 +150,14 @@ public:
   int MakePeriodic(const int continuity) {return 0;} /**< \brief Unimplemented */
 
   /** \brief get the knot vector multiplicity. */
-  int GetMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots) {return 0;} /**< \brief Unimplemented */
+  int GetMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots);
 
   // Description:
   // Retrieve an instance of this class from an information object.
   static vtkSVNURBSCurve* GetData(vtkInformation* info);
   static vtkSVNURBSCurve* GetData(vtkInformationVector* v, int i=0);
+
+  virtual void DeepCopy(vtkSVNURBSCurve *src);
 
 protected:
   vtkSVNURBSCurve();

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.cxx
@@ -468,9 +468,6 @@ int vtkSVNURBSSurface::GetVMultiplicity(vtkIntArray *multiplicity, vtkDoubleArra
 // ----------------------
 int vtkSVNURBSSurface::GetMultiplicity(const int dim, vtkIntArray *multiplicity, vtkDoubleArray *singleKnots)
 {
-  fprintf(stdout,"WJAT TJT: %lld\n", this->UVKnotVectors[dim]->GetNumberOfTuples());
-  fprintf(stdout,"WJAT U: %lld\n", this->UKnotVector->GetNumberOfTuples());
-  fprintf(stdout,"WJAT V: %lld\n", this->VKnotVector->GetNumberOfTuples());
   vtkSVNURBSUtils::GetMultiplicity(this->UVKnotVectors[dim], multiplicity, singleKnots);
   return SV_OK;
 }

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.cxx
@@ -102,6 +102,29 @@ vtkSVNURBSSurface::~vtkSVNURBSSurface()
 }
 
 // ----------------------
+// DeepCopy
+// ----------------------
+void vtkSVNURBSSurface::DeepCopy(vtkSVNURBSSurface *src)
+{
+  this->Superclass::DeepCopy(src);
+
+  this->SetNumberOfUControlPoints(src->GetNumberOfUControlPoints());
+  this->SetNumberOfVControlPoints(src->GetNumberOfVControlPoints());
+  this->SetNumberOfUKnotPoints(src->GetNumberOfUKnotPoints());
+  this->SetNumberOfVKnotPoints(src->GetNumberOfVKnotPoints());
+  this->SetUDegree(src->GetUDegree());
+  this->SetVDegree(src->GetVDegree());
+
+  this->ControlPointGrid->DeepCopy(src->GetControlPointGrid());
+  this->UKnotVector->DeepCopy(src->GetUKnotVector());
+  this->VKnotVector->DeepCopy(src->GetVKnotVector());
+  this->UWeights->DeepCopy(src->GetUWeights());
+  this->VWeights->DeepCopy(src->GetVWeights());
+
+  this->SurfaceRepresentation->DeepCopy(src->GetSurfaceRepresentation());
+}
+
+// ----------------------
 // PrintSelf
 // ----------------------
 void vtkSVNURBSSurface::PrintSelf(ostream& os, vtkIndent indent)
@@ -419,6 +442,36 @@ int vtkSVNURBSSurface::GeneratePolyDataRepresentation(const double uSpacing,
   this->SurfaceRepresentation->DeepCopy(cleaner->GetOutput());
   this->SurfaceRepresentation->BuildLinks();
 
+  return SV_OK;
+}
+
+// ----------------------
+// GetUMultiplicity
+// ----------------------
+int vtkSVNURBSSurface::GetUMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots)
+{
+  this->GetMultiplicity(0, multiplicity, singleKnots);
+  return SV_OK;
+}
+
+// ----------------------
+// GetVMultiplicity
+// ----------------------
+int vtkSVNURBSSurface::GetVMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots)
+{
+  this->GetMultiplicity(1, multiplicity, singleKnots);
+  return SV_OK;
+}
+
+// ----------------------
+// GetMultiplicity
+// ----------------------
+int vtkSVNURBSSurface::GetMultiplicity(const int dim, vtkIntArray *multiplicity, vtkDoubleArray *singleKnots)
+{
+  fprintf(stdout,"WJAT TJT: %lld\n", this->UVKnotVectors[dim]->GetNumberOfTuples());
+  fprintf(stdout,"WJAT U: %lld\n", this->UKnotVector->GetNumberOfTuples());
+  fprintf(stdout,"WJAT V: %lld\n", this->VKnotVector->GetNumberOfTuples());
+  vtkSVNURBSUtils::GetMultiplicity(this->UVKnotVectors[dim], multiplicity, singleKnots);
   return SV_OK;
 }
 

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.h
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSSurface.h
@@ -78,21 +78,41 @@ public:
   vtkGetMacro(NumberOfVKnotPoints, int);
   vtkSetMacro(NumberOfVKnotPoints, int);
   //@}
+  //
+  //@{
+  /// \brief Get and set the degree
+  vtkGetMacro(UDegree, int);
+  vtkSetMacro(UDegree, int);
+  vtkGetMacro(VDegree, int);
+  vtkSetMacro(VDegree, int);
+  //@}
 
   //@{
   // / \brief Set the control point grid
   vtkGetObjectMacro(ControlPointGrid, vtkSVControlGrid);
+  vtkSetObjectMacro(ControlPointGrid, vtkSVControlGrid);
   //@}
 
   //@{
   // / \brief Get and set the knot vector object
   vtkGetObjectMacro(UKnotVector, vtkDoubleArray);
+  vtkSetObjectMacro(UKnotVector, vtkDoubleArray);
   vtkGetObjectMacro(VKnotVector, vtkDoubleArray);
+  vtkSetObjectMacro(VKnotVector, vtkDoubleArray);
+  //@}
+
+  //@{
+  // / \brief Get and set the weights
+  vtkGetObjectMacro(UWeights, vtkDoubleArray);
+  vtkSetObjectMacro(UWeights, vtkDoubleArray);
+  vtkGetObjectMacro(VWeights, vtkDoubleArray);
+  vtkSetObjectMacro(VWeights, vtkDoubleArray);
   //@}
 
   //@{
   // / \brief Get the PolyData Representation
   vtkGetObjectMacro(SurfaceRepresentation, vtkPolyData);
+  vtkSetObjectMacro(SurfaceRepresentation, vtkPolyData);
   //@}
 
   // Initialize
@@ -106,7 +126,6 @@ public:
   int GeneratePolyDataRepresentation(const double uSpacing, const double vSpacing);
 
   //Functions to set control points/knots/etc.
-  void SetControlPointGrid(vtkSVControlGrid *controlPoints) {} /**< \brief Unimplemented */
   void SetControlPoints(vtkStructuredGrid *points2d);
   void SetKnotVector(vtkDoubleArray *knotVector, const int dim);
 
@@ -119,7 +138,7 @@ public:
   int SetKnot(const int index, const int dim, const double newKnot) {return 0;} /**< \brief Unimplemented */
   int SetKnots(vtkIntArray *indices, const int dim, vtkDoubleArray *newKnots) {return 0;} /**< \brief Unimplemented */
   int GetKnot(const int index, const int dim, double &knotVal) {return 0;} /**< \brief Unimplemented */
-  int GetKNots(const int indices, const int dim, vtkDoubleArray *knotVals) {return 0;} /**< \brief Unimplemented */
+  int GetKnots(const int indices, const int dim, vtkDoubleArray *knotVals) {return 0;} /**< \brief Unimplemented */
 
   int SetControlPoint(const int index, const int dim, const double coordinate[3], const double weight) {return 0;} /**< \brief Unimplemented */
   int SetControlPoints(vtkIntArray *indices, const int dim, vtkPoints *coordinates, vtkDoubleArray *weights); /**< \brief Unimplemented */
@@ -134,7 +153,9 @@ public:
   int MakePeriodic(const int continuity, const int dim) {return 0;} /**< \brief Unimplemented */
 
   /** \brief get the knot vector multiplicity. */
-  int GetMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots) {return 0;} /**< \brief Unimplemented */
+  int GetUMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots);
+  int GetVMultiplicity(vtkIntArray *multiplicity, vtkDoubleArray *singleKnots);
+  int GetMultiplicity(const int dim, vtkIntArray *multiplicity, vtkDoubleArray *singleKnots);
 
   /** \brief Get structured grid connectivity.
    *  \param connectivity empty cell array to be filled with a structured grid connectivity. */
@@ -144,6 +165,8 @@ public:
   // Retrieve an instance of this class from an information object.
   static vtkSVNURBSSurface* GetData(vtkInformation* info);
   static vtkSVNURBSSurface* GetData(vtkInformationVector* v, int i=0);
+
+  virtual void DeepCopy(vtkSVNURBSSurface *src);
 
 protected:
   vtkSVNURBSSurface();

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.cxx
@@ -1092,6 +1092,53 @@ int vtkSVNURBSUtils::FindSpan(int p, double u, vtkDoubleArray *knots, int &span)
 }
 
 // ----------------------
+// FindSpan
+// ----------------------
+int vtkSVNURBSUtils::GetMultiplicity(vtkDoubleArray *array, vtkIntArray *multiplicity,
+                                     vtkDoubleArray *singleValues)
+{
+  // Reset the return arrays
+  multiplicity->Reset();
+  singleValues->Reset();
+
+  // Number of values
+  int numVals = array->GetNumberOfTuples();
+
+  // Loop through values
+  for (int i=0; i<numVals-1; i++)
+  {
+    int count = 1;
+    while(array->GetTuple1(i+1) == array->GetTuple1(i) && i<numVals)
+    {
+      count++;
+      i++;
+    }
+
+    // Update mults
+    multiplicity->InsertNextTuple1(count);
+    singleValues->InsertNextTuple1(array->GetTuple1(i));
+  }
+
+  // Number of mult vals
+  int numMults = singleValues->GetNumberOfTuples();
+
+  // Set the last spot of the array
+  if (array->GetTuple1(numVals-1) == singleValues->GetTuple1(numMults-1))
+  {
+  // If the last spot is equal to second to last, incr by one
+    multiplicity->SetTuple1(numMults-1, multiplicity->GetTuple1(numMults-1) + 1);
+  }
+  else
+  {
+    // Add new mult because not equal
+    multiplicity->InsertNextTuple1(1);
+    singleValues->InsertNextTuple1(array->GetTuple1(numVals-1));
+  }
+
+  return SV_OK;
+}
+
+// ----------------------
 // MatrixPointsMultiply
 // ----------------------
 int vtkSVNURBSUtils::MatrixPointsMultiply(vtkTypedArray<double>* mat, vtkPoints *pointVec, vtkPoints *output)

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.cxx
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.cxx
@@ -1103,6 +1103,8 @@ int vtkSVNURBSUtils::GetMultiplicity(vtkDoubleArray *array, vtkIntArray *multipl
 
   // Number of values
   int numVals = array->GetNumberOfTuples();
+  if (numVals == 0)
+    return SV_ERROR;
 
   // Loop through values
   for (int i=0; i<numVals-1; i++)
@@ -1122,14 +1124,8 @@ int vtkSVNURBSUtils::GetMultiplicity(vtkDoubleArray *array, vtkIntArray *multipl
   // Number of mult vals
   int numMults = singleValues->GetNumberOfTuples();
 
-  // Set the last spot of the array
-  if (array->GetTuple1(numVals-1) == singleValues->GetTuple1(numMults-1))
-  {
-  // If the last spot is equal to second to last, incr by one
-    multiplicity->SetTuple1(numMults-1, multiplicity->GetTuple1(numMults-1) + 1);
-  }
-  else
-  {
+  // Set the last spot of the array if needed
+  if (array->GetTuple1(numVals-1) != singleValues->GetTuple1(numMults-1)){
     // Add new mult because not equal
     multiplicity->InsertNextTuple1(1);
     singleValues->InsertNextTuple1(array->GetTuple1(numVals-1));

--- a/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.h
+++ b/Code/Source/vtkSV/Modules/NURBS/vtkSVNURBSUtils.h
@@ -120,6 +120,7 @@ public:
   static int BasisEvaluationVec(vtkDoubleArray *knots, int p, int kEval, vtkDoubleArray *uEvals,
                              vtkTypedArray<double> *Nus);
   static int FindSpan(int p, double u, vtkDoubleArray *knots, int &span);
+  static int GetMultiplicity(vtkDoubleArray *array, vtkIntArray *multiplicity, vtkDoubleArray *singleValues);
 
   //Conversion functions
   static int PolyDatasToStructuredGrid(vtkPolyData **inputs, const int numInputs, vtkStructuredGrid *points);


### PR DESCRIPTION
DEV: Adds nurbs lofting to OpenCASCADE and preferences page

A model preferences page was created containing the lofting preferences for NURBS.
The nurbs lofting is now available under the PolyData and OpenCASCADE modeling by selecting advanced lofting in the select segmentation window pane. The name can be changed if people don't like "advanced". Can also be made default lofting after testing.