### PR TITLE
2017 6 29 tetgen multidomain

### DIFF
--- a/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.cxx
+++ b/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.cxx
@@ -1219,10 +1219,32 @@ int cvTetGenMeshObject::GenerateMesh() {
   //to re-set up the mesh based on sizing function for sphere refinement
   if (meshoptions_.volumemeshflag && !meshoptions_.surfacemeshflag)
   {
-    if (TGenUtils_CheckSurfaceMesh(polydatasolid_,
-	  meshoptions_.boundarylayermeshflag) != SV_OK)
+    int meshInfo[3];
+    if (TGenUtils_CheckSurfaceMesh(polydatasolid_, meshInfo) != SV_OK)
     {
-      fprintf(stderr,"Mesh surface is bad\n");
+      fprintf(stderr,"Error checking surface\n");
+      return SV_ERROR;
+    }
+
+    if (meshInfo[0] > 0)
+    {
+      if (meshInfo[0] != meshoptions_.numberofholes)
+      {
+        fprintf(stderr,"There are too many regions here!\n");
+        fprintf(stderr,"Terminating meshing!\n");
+        return SV_ERROR;
+      }
+    }
+    if (meshInfo[1] > 0 && !meshoptions_.boundarylayermeshflag)
+    {
+      fprintf(stderr,"There are free edes on surface!\n");
+      fprintf(stderr,"Terminating meshing!\n");
+      return SV_ERROR;
+    }
+    if (meshInfo[2] > 0)
+    {
+      fprintf(stderr,"There are bad edes on surface!\n");
+      fprintf(stderr,"Terminating meshing!\n");
       return SV_ERROR;
     }
     NewMesh();
@@ -1605,10 +1627,32 @@ int cvTetGenMeshObject::GenerateSurfaceRemesh()
   }
 #endif
 
-  if (TGenUtils_CheckSurfaceMesh(polydatasolid_,
-	  meshoptions_.meshwallfirst) != SV_OK)
+  int meshInfo[3];
+  if (TGenUtils_CheckSurfaceMesh(polydatasolid_, meshInfo) != SV_OK)
   {
     fprintf(stderr,"Mesh surface is bad\n");
+    return SV_ERROR;
+  }
+
+  if (meshInfo[0] > 0)
+  {
+    if (meshInfo[0] != meshoptions_.numberofholes)
+    {
+      fprintf(stderr,"There are too many regions here!\n");
+      fprintf(stderr,"Terminating meshing!\n");
+      return SV_ERROR;
+    }
+  }
+  if (meshInfo[1] > 0 && !meshoptions_.meshwallfirst)
+  {
+    fprintf(stderr,"There are free edes on surface!\n");
+    fprintf(stderr,"Terminating meshing!\n");
+    return SV_ERROR;
+  }
+  if (meshInfo[2] > 0)
+  {
+    fprintf(stderr,"There are bad edes on surface!\n");
+    fprintf(stderr,"Terminating meshing!\n");
     return SV_ERROR;
   }
 

--- a/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
@@ -83,6 +83,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
     double cylindercenter[3];
     double cylinderlength;
     double cylindernormal[3];
+    int numberofholes;
     int functionbasedmeshing;
     int secondarrayfunction;
     int meshwallfirst;
@@ -180,6 +181,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
 
   vtkPolyData *originalpolydata_;
   vtkPolyData *surfacemesh_;
+  vtkPoints   *holelist_;
   vtkUnstructuredGrid *volumemesh_;
   vtkUnstructuredGrid *boundarylayermesh_;
   vtkUnstructuredGrid *innerblmesh_;

--- a/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
@@ -84,6 +84,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
     double cylinderlength;
     double cylindernormal[3];
     int numberofholes;
+    int numberofregions;
     int functionbasedmeshing;
     int secondarrayfunction;
     int meshwallfirst;
@@ -182,6 +183,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
   vtkPolyData *originalpolydata_;
   vtkPolyData *surfacemesh_;
   vtkPoints   *holelist_;
+  vtkPoints   *regionlist_;
   vtkUnstructuredGrid *volumemesh_;
   vtkUnstructuredGrid *boundarylayermesh_;
   vtkUnstructuredGrid *innerblmesh_;

--- a/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cvTetGenMeshObject.h
@@ -184,6 +184,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
   vtkPolyData *surfacemesh_;
   vtkPoints   *holelist_;
   vtkPoints   *regionlist_;
+  vtkDoubleArray *regionsizelist_;
   vtkUnstructuredGrid *volumemesh_;
   vtkUnstructuredGrid *boundarylayermesh_;
   vtkUnstructuredGrid *innerblmesh_;

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.cxx
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.cxx
@@ -254,6 +254,28 @@ int TGenUtils_AddHoles(tetgenio *inmesh, vtkPoints *holeList)
 }
 
 // -----------------------------
+// cvTGenUtils_AddRegions
+// -----------------------------
+/**
+ */
+int TGenUtils_AddRegions(tetgenio *inmesh, vtkPoints *regionList)
+{
+  inmesh->numberofholes = holeList->GetNumberOfPoints();
+  inmesh->holelist = new REAL[inmesh->numberofholes * 3];
+
+  for (int i=0; i<inmesh->numberofholes; i++)
+  {
+    double pt[3];
+    holeList->GetPoint(i, pt);
+    inmesh->holelist[3*i] =   pt[0];
+    inmesh->holelist[3*i+1] = pt[1];
+    inmesh->holelist[3*i+2] = pt[2];
+  }
+
+  return SV_OK;
+}
+
+// -----------------------------
 // cvTGenUtils_ConvertVolumeToTetGen()
 // -----------------------------
 /**

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
@@ -65,6 +65,8 @@ SV_EXPORT_TETGEN_MESH int TGenUtils_AddFacetMarkers(tetgenio *inmesh,vtkPolyData
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_AddHoles(tetgenio *inmesh, vtkPoints *holeList);
 
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddRegions(tetgenio *inmesh, vtkPoints *regionList);
+
 SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertVolumeToTetGen(vtkUnstructuredGrid *mesh,
     vtkPolyData *surfaceMesh,tetgenio *inmesh);
 

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
@@ -98,7 +98,7 @@ SV_EXPORT_TETGEN_MESH int TGenUtils_LoadMesh(char *filename,vtkUnstructuredGrid 
 SV_EXPORT_TETGEN_MESH int TGenUtils_ResetOriginalRegions(vtkPolyData *newgeom,
     vtkPolyData *originalgeom,std::string newName,std::string originalName);
 
-SV_EXPORT_TETGEN_MESH int TGenUtils_CheckSurfaceMesh(vtkPolyData *pd,int boundarylayer);
+SV_EXPORT_TETGEN_MESH int TGenUtils_CheckSurfaceMesh(vtkPolyData *pd, int meshInfo[3]);
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_SetLocalMeshSize(vtkPolyData *pd,int regionId,double size);
 

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
@@ -65,7 +65,7 @@ SV_EXPORT_TETGEN_MESH int TGenUtils_AddFacetMarkers(tetgenio *inmesh,vtkPolyData
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_AddHoles(tetgenio *inmesh, vtkPoints *holeList);
 
-SV_EXPORT_TETGEN_MESH int TGenUtils_AddRegions(tetgenio *inmesh, vtkPoints *regionList);
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddRegions(tetgenio *inmesh, vtkPoints *regionList, vtkDoubleArray *regionSizeList);
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertVolumeToTetGen(vtkUnstructuredGrid *mesh,
     vtkPolyData *surfaceMesh,tetgenio *inmesh);

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
@@ -59,9 +59,11 @@ SV_EXPORT_TETGEN_MESH int TGenUtils_Init();
 //
 SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertSurfaceToTetGen(tetgenio *inmesh,vtkPolyData *polydatasolid);
 
-SV_EXPORT_TETGEN_MESH int TGenUtils_AddPointSizingFunction(tetgenio *inmesh,vtkPolyData *polydatasolid, vtkDoubleArray *meshSizingFunction, double maxEdgeSize);
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddPointSizingFunction(tetgenio *inmesh,vtkPolyData *polydatasolid, std::string meshSizingFunctionName, double maxEdgeSize);
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_AddFacetMarkers(tetgenio *inmesh,vtkPolyData *polydatasolid, std::string markerListArrayName);
+
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddHoles(tetgenio *inmesh, vtkPoints *holeList);
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertVolumeToTetGen(vtkUnstructuredGrid *mesh,
     vtkPolyData *surfaceMesh,tetgenio *inmesh);

--- a/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
+++ b/Code/Source/Mesh/TetGenMeshObject/cv_tetgenmesh_utils.h
@@ -57,9 +57,11 @@ SV_EXPORT_TETGEN_MESH int TGenUtils_Init();
 //int cvTetGenMeshObjectUtils_Logon(char *filename);
 //int cvTetGenMeshObjectUtils_Logoff();
 //
-SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertSurfaceToTetGen(tetgenio *inmesh,vtkPolyData *polydatasolid,
-    int meshsizingfunction, vtkDoubleArray *meshSizingFunction,
-    int useBoundary, std::string markerListArrayName, double maxEdgeSize);
+SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertSurfaceToTetGen(tetgenio *inmesh,vtkPolyData *polydatasolid);
+
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddPointSizingFunction(tetgenio *inmesh,vtkPolyData *polydatasolid, vtkDoubleArray *meshSizingFunction, double maxEdgeSize);
+
+SV_EXPORT_TETGEN_MESH int TGenUtils_AddFacetMarkers(tetgenio *inmesh,vtkPolyData *polydatasolid, std::string markerListArrayName);
 
 SV_EXPORT_TETGEN_MESH int TGenUtils_ConvertVolumeToTetGen(vtkUnstructuredGrid *mesh,
     vtkPolyData *surfaceMesh,tetgenio *inmesh);

--- a/Code/Source/Model/PolyDataSolidModel/vtkGetBoundaryFaces.cxx
+++ b/Code/Source/Model/PolyDataSolidModel/vtkGetBoundaryFaces.cxx
@@ -1,19 +1,19 @@
 /*=========================================================================
  *
  * Copyright (c) 2014-2015 The Regents of the University of California.
- * All Rights Reserved. 
+ * All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining
  * a copy of this software and associated documentation files (the
- * "Software"), to deal in the Software without restriction, including 
- * without limitation the rights to use, copy, modify, merge, publish, 
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
  * distribute, sublicense, and/or sell copies of the Software, and to
  * permit persons to whom the Software is furnished to do so, subject
  * to the following conditions:
- * 
- * The above copyright notice and this permission notice shall be included 
+ *
+ * The above copyright notice and this permission notice shall be included
  * in all copies or substantial portions of the Software.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
  * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
  * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
@@ -32,9 +32,9 @@
  *  @brief This implements the vtkGetBoundaryFaces filter as a class
  *
  *  @author Adam Updegrove
- *  @author updega2@gmail.com 
+ *  @author updega2@gmail.com
  *  @author UC Berkeley
- *  @author shaddenlab.berkeley.edu 
+ *  @author shaddenlab.berkeley.edu
  */
 
 #include "vtkGetBoundaryFaces.h"
@@ -69,29 +69,29 @@ vtkStandardNewMacro(vtkGetBoundaryFaces);
 // Construct object with feature angle = 50.0;
 vtkGetBoundaryFaces::vtkGetBoundaryFaces()
 {
-/** 
+/**
  * @brief member data that is the Feature Edges filter. Extracts edges!
  */
     this->boundaries = vtkFeatureEdges::New();
-/** 
- * @Default angle of extraction. Can be easily changed by setting Feature 
+/**
+ * @Default angle of extraction. Can be easily changed by setting Feature
  * Angle
  */
     this->FeatureAngle = 50.0;
-/** 
- * @brief Integer Array containing the values associated with the region 
+/**
+ * @brief Integer Array containing the values associated with the region
  * number at each face
  */
     this->newScalars = vtkIntArray::New();
-/** 
+/**
  * @brief PolyData that contains the output mesh with region scalars
  */
     this->mesh = vtkPolyData::New();
-/** 
+/**
  * @brief The series of points and lines output from the Feature Edges filter
  */
     this->boundaryLines = vtkPolyData::New();
-/** 
+/**
  * @brief The list of cell Ids that have been checked
  */
     this->CheckCells = vtkIdList::New();
@@ -164,10 +164,10 @@ int vtkGetBoundaryFaces::RequestData(
     // get the input and output
     vtkPolyData *input = vtkPolyData::GetData(inputVector[0]);
     vtkPolyData *output = vtkPolyData::GetData(outputVector);
-    
+
     // Define variables used by the algorithm
-    int reg = 0;                                          
-    int pt = 0;                                          
+    int reg = 0;
+    int pt = 0;
     vtkSmartPointer<vtkPoints> inpts = vtkSmartPointer<vtkPoints>::New();
     vtkSmartPointer<vtkCellArray> inPolys = vtkSmartPointer<vtkCellArray>::New();
     vtkPoints *newPts;
@@ -187,7 +187,7 @@ int vtkGetBoundaryFaces::RequestData(
     numPts = input->GetNumberOfPoints();
 
     //Check the input to make sure it is there
-    if (numPolys < 1)               
+    if (numPolys < 1)
     {
         vtkDebugMacro("No input!");
 	return 1;
@@ -213,7 +213,7 @@ int vtkGetBoundaryFaces::RequestData(
     this->boundaryLines->DeepCopy(this->boundaries->GetOutput());
     //this->boundaryLines->BuildLinks();
     //std::cout<<"Number Points: "<<this->boundaryLines->GetNumberOfPoints()<<endl;
- 
+
     this->SetBoundaryArrays();
 
     vtkDebugMacro("Starting Boundary Face Separation");
@@ -274,11 +274,11 @@ void vtkGetBoundaryFaces::FindBoundaryRegion(int reg,int start)
 {
     //Variables used in function
     int i;
-    vtkIdType j,k,l,cellId; 
+    vtkIdType j,k,l,cellId;
     vtkIdType *pts = 0;
     vtkIdType npts = 0;
     vtkIdType numNei, nei, p1, p2, nIds, neis;
-    
+
     //Id List to store neighbor cells for each set of nodes and a cell
     vtkSmartPointer<vtkIdList> neighbors = vtkSmartPointer<vtkIdList>::New();
     vtkSmartPointer<vtkIdList> tmp = vtkSmartPointer<vtkIdList>::New();
@@ -330,7 +330,7 @@ void vtkGetBoundaryFaces::FindBoundaryRegion(int reg,int start)
 		  this->CheckCellsCareful2->Reset();
 		}
 	      }
-	      //Cell needs to be added to check list 
+	      //Cell needs to be added to check list
 	      else
 	      {
 		this->CheckCells2->InsertNextId(neighbors->GetId(j));
@@ -366,7 +366,7 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
   //std::cout<<"Am tip toeing"<<endl;
     //Variables used in function
     int i;
-    vtkIdType j,k,l; 
+    vtkIdType j,k,l;
     vtkIdType *pts = 0;
     vtkIdType npts = 0;
     vtkIdType cellId;
@@ -378,7 +378,7 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
 
     //Variable for accessing neiIds list
     vtkIdType sz = 0;
-    
+
     //Variables for the boundary cells adjacent to the boundary point
     vtkSmartPointer<vtkIdList> bLinesOne = vtkSmartPointer<vtkIdList>::New();
     vtkSmartPointer<vtkIdList> bLinesTwo = vtkSmartPointer<vtkIdList>::New();
@@ -396,7 +396,7 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
 	this->mesh->GetCellPoints(cellId,npts,pts);
 	if (this->checkedcarefully[cellId] == 0)
 	{
-          //Update this cell to have been checked carefully and assign it 
+          //Update this cell to have been checked carefully and assign it
 	  //with the fillnumber scalar
           this->newScalars->InsertValue(cellId,reg);
 	  this->checkedcarefully[cellId] = 1;
@@ -407,18 +407,18 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
 	    p1 = pts[i];
 	    p2 = pts[(i+1)%(npts)];
 
-            vtkSmartPointer<vtkIdList> neighbors = 
+            vtkSmartPointer<vtkIdList> neighbors =
 	      vtkSmartPointer<vtkIdList>::New();
 	    //Initial check to make sure the cell is in fact a face cell
 	    this->mesh->GetCellEdgeNeighbors(cellId,p1,p2,neighbors);
 	    numNei = neighbors->GetNumberOfIds();
 
-	    //Check to make sure it is an oustide surface cell, 
+	    //Check to make sure it is an oustide surface cell,
 	    //i.e. one neighbor
 	    if (numNei==1)
 	    {
               int count = 0;
-		//Check to see if cell is on the boundary, 
+		//Check to see if cell is on the boundary,
 		//if it is get adjacent lines
 	      if (this->BoundaryPointArray->GetValue(p1) == 1)
 	        count++;
@@ -432,9 +432,9 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
 	      {
 		neiIds->InsertNextId(nei);
 	      }
-	      //if cell is on boundary, check to make sure it isn't 
+	      //if cell is on boundary, check to make sure it isn't
 	      //false positive; don't add to check list. This is done by
-	      //getting the boundary lines attached to each point, then 
+	      //getting the boundary lines attached to each point, then
 	      //intersecting the two lists. If the result is zero, then this
 	      //is a false positive
 	      else
@@ -447,7 +447,7 @@ void vtkGetBoundaryFaces::FindBoundaryRegionTipToe(int reg)
 		this->boundaryLines->GetPointCells(bPt2,bLinesTwo);
 
 		bLinesOne->IntersectWith(bLinesTwo);
-		//Cell is false positive. Add to check list. 
+		//Cell is false positive. Add to check list.
 		if (bLinesOne->GetNumberOfIds() == 0)
 		{
 	          //std::cout<<"False positive! "<<nei<<endl;
@@ -503,11 +503,11 @@ void vtkGetBoundaryFaces::SetBoundaryArrays()
   //Variables used in the function
   double pt[3];
   vtkIdType pointId,bp,bp2,i;
-  vtkSmartPointer<vtkIdList> bpCellIds = 
+  vtkSmartPointer<vtkIdList> bpCellIds =
     vtkSmartPointer<vtkIdList>::New();
   //Point locator to find points on mesh that are the points on the boundary
   //lines
-  vtkSmartPointer<vtkPointLocator> pointLocator = 
+  vtkSmartPointer<vtkPointLocator> pointLocator =
     vtkSmartPointer<vtkPointLocator>::New();
   pointLocator->SetDataSet(this->mesh);
   pointLocator->BuildLocator();
@@ -519,7 +519,7 @@ void vtkGetBoundaryFaces::SetBoundaryArrays()
   this->pointMapper = new vtkIdType[numMeshCells];
   this->BoundaryPointArray->SetNumberOfTuples(numMeshPoints);
   this->BoundaryCellArray->SetNumberOfTuples(numMeshCells);
-  
+
   for (int i =0;i<numMeshPoints;i++)
   {
     this->BoundaryPointArray->InsertValue(i,0);
@@ -535,7 +535,7 @@ void vtkGetBoundaryFaces::SetBoundaryArrays()
   for (pointId = 0;pointId < numPoints;pointId++)
   {
     this->boundaryLines->GetPoint(pointId,pt);
-    //Find point on mesh 
+    //Find point on mesh
     bp = pointLocator->FindClosestPoint(pt);
     this->pointMapper[bp] = pointId;
     this->BoundaryPointArray->InsertValue(bp,1);
@@ -543,7 +543,7 @@ void vtkGetBoundaryFaces::SetBoundaryArrays()
     //Set the point mapping array
     //Assign each cell attached to this point as a boundary cell
     for (i = 0;i < bpCellIds->GetNumberOfIds();i++)
-    { 
+    {
       this->BoundaryCellArray->InsertValue(bpCellIds->GetId(i),1);
       this->checked[bpCellIds->GetId(i)] = 1;
     }

--- a/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
+++ b/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
@@ -412,12 +412,13 @@ bool svMeshTetGen::ParseCommand(std::string cmd, std::string& flag, double value
             values[2]=std::stod(params[3]);
             option=true;
         }
-        else if(paramSize==4 && params[0]=="addsubdomain")
+        else if(paramSize==5 && params[0]=="addsubdomain")
         {
           flag="AddSubDomain";
           values[0]=std::stod(params[1]);
           values[1]=std::stod(params[2]);
           values[2]=std::stod(params[3]);
+          values[3]=std::stod(params[4]);
           option=true;
         }
         else

--- a/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
+++ b/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
@@ -404,6 +404,14 @@ bool svMeshTetGen::ParseCommand(std::string cmd, std::string& flag, double value
             values[0]=std::stod(params[1]);
             option=true;
         }
+        else if(paramSize==4 && params[0]=="addhole")
+        {
+            flag="AddHole";
+            values[0]=std::stod(params[1]);
+            values[1]=std::stod(params[2]);
+            values[2]=std::stod(params[3]);
+            option=true;
+        }
         else
         {
             msg="Unknown command: "+originalCmd;

--- a/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
+++ b/Code/Source/Modules/Mesh/Common/svMeshTetGen.cxx
@@ -412,6 +412,14 @@ bool svMeshTetGen::ParseCommand(std::string cmd, std::string& flag, double value
             values[2]=std::stod(params[3]);
             option=true;
         }
+        else if(paramSize==4 && params[0]=="addsubdomain")
+        {
+          flag="AddSubDomain";
+          values[0]=std::stod(params[1]);
+          values[1]=std::stod(params[2]);
+          values[2]=std::stod(params[3]);
+          option=true;
+        }
         else
         {
             msg="Unknown command: "+originalCmd;

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.cxx
@@ -188,6 +188,7 @@ void svMeshEdit::SetupGUI(QWidget *parent )
 
     //for multi-domains
     connect(ui->btnAddHole, SIGNAL(clicked()), this, SLOT(AddHole()) );
+    connect(ui->btnAddSumDomain, SIGNAL(clicked()), this, SLOT(AddSumDomain()) );
 
     m_TableModelDomains = new QStandardItemModel(this);
     ui->tableViewDomains->setModel(m_TableModelDomains);
@@ -806,9 +807,18 @@ std::vector<std::string> svMeshEdit::CreateCmdsT()
         QString params=itemParams->text();
         QStringList plist = params.split(QRegExp("\\s+"));
 
-        if(!plist.isEmpty())
-            cmds.push_back("option AddHole " + plist[0].toStdString()
-                    + " " + plist[1].toStdString() + " " + plist[2].toStdString());
+        if (itemType=="Hole")
+        {
+          if(!plist.isEmpty())
+              cmds.push_back("option AddHole " + plist[0].toStdString()
+                      + " " + plist[1].toStdString() + " " + plist[2].toStdString());
+        }
+        else if (itemType=="SubDomain")
+        {
+          if(!plist.isEmpty())
+              cmds.push_back("option AddSubDomain " + plist[0].toStdString()
+                      + " " + plist[1].toStdString() + " " + plist[2].toStdString());
+        }
     }
 
     cmds.push_back("generateMesh");
@@ -1404,6 +1414,20 @@ void svMeshEdit::UpdateTetGenGUI()
           item= new QStandardItem(QString::number(values[1])+" "+QString::number(values[2])+" "+QString::number(values[3]));
           m_TableModelDomains->setItem(domainsRowIndex, 1, item);
         }
+        else if (flag=="AddSumDomain")
+        {
+          domainsRowIndex++;
+          m_TableModelDomains->insertRow(domainsRowIndex);
+
+          QStandardItem* item;
+
+          item= new QStandardItem("SubDomain");
+          item->setEditable(false);
+          m_TableModelDomains->setItem(domainsRowIndex, 0, item);
+
+          item= new QStandardItem(QString::number(values[1])+" "+QString::number(values[2])+" "+QString::number(values[3]));
+          m_TableModelDomains->setItem(domainsRowIndex, 1, item);
+        }
         else
         {
             //do nothing
@@ -1778,6 +1802,20 @@ void svMeshEdit::AddHole()
     QStandardItem* item;
 
     item= new QStandardItem("Hole");
+    item->setEditable(false);
+    m_TableModelDomains->setItem(regionRowIndex, 0, item);
+
+    item= new QStandardItem("0.0 0.0 0.0");
+    m_TableModelDomains->setItem(regionRowIndex, 1, item);
+}
+
+void svMeshEdit::AddSubDomain()
+{
+    int regionRowIndex=m_TableModelDomains->rowCount();
+
+    QStandardItem* item;
+
+    item= new QStandardItem("SubDomain");
     item->setEditable(false);
     m_TableModelDomains->setItem(regionRowIndex, 0, item);
 

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.cxx
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.cxx
@@ -58,9 +58,13 @@ svMeshEdit::svMeshEdit() :
     m_TableModelRegion=NULL;
     m_TableMenuRegion=NULL;
 
+    m_TableModelDomains=NULL;
+    m_TableMenuDomains=NULL;
+
     m_SphereWidget=NULL;
 
     m_SelectedRegionIndex=-1;
+    m_SelectedDomainsIndex=-1;
 
     m_UndoAble=false;
 
@@ -85,6 +89,12 @@ svMeshEdit::~svMeshEdit()
 
     if(m_TableMenuRegion)
         delete m_TableMenuRegion;
+
+    if(m_TableMenuDomains)
+        delete m_TableMenuDomains;
+
+    if(m_TableModelDomains)
+        delete m_TableModelDomains;
 
     if(m_CustomDelegate)
         delete m_CustomDelegate;
@@ -175,6 +185,21 @@ void svMeshEdit::SetupGUI(QWidget *parent )
 
     connect( ui->tableViewRegion, SIGNAL(customContextMenuRequested(const QPoint&))
       , this, SLOT(TableViewRegionContextMenuRequested(const QPoint&)) );
+
+    //for multi-domains
+    connect(ui->btnAddHole, SIGNAL(clicked()), this, SLOT(AddHole()) );
+
+    m_TableModelDomains = new QStandardItemModel(this);
+    ui->tableViewDomains->setModel(m_TableModelDomains);
+
+    connect( ui->tableViewDomains->selectionModel()
+      , SIGNAL( selectionChanged ( const QItemSelection &, const QItemSelection & ) )
+      , this
+      , SLOT( TableDomainsListSelectionChanged ( const QItemSelection &, const QItemSelection & ) ) );
+
+    m_TableMenuDomains=new QMenu(ui->tableViewDomains);
+    QAction* deleteDomainsTAction=m_TableMenuDomains->addAction("Delete");
+    connect( deleteDomainsTAction, SIGNAL( triggered(bool) ) , this, SLOT( DeleteSelectedDomains(bool) ) );
 
     //for adaptor
     connect(ui->comboBoxOption, SIGNAL(currentIndexChanged(int)), this, SLOT(UpdateAdaptGUI(int)));
@@ -365,6 +390,43 @@ void svMeshEdit::TableRegionListSelectionChanged( const QItemSelection & /*selec
     mitk::RenderingManager::GetInstance()->RequestUpdateAll();
 }
 
+void svMeshEdit::TableDomainsListSelectionChanged( const QItemSelection & /*selected*/, const QItemSelection & /*deselected*/ )
+{
+    if(!m_Model)
+        return;
+
+    int timeStep=GetTimeStep();
+    svModelElement* modelElement=m_Model->GetModelElement(timeStep);
+    if(modelElement==NULL) return;
+
+    QStandardItemModel* tableModel=m_TableModelDomains;
+    QTableView* tableView=ui->tableViewDomains;
+
+    if(tableModel==NULL || tableView==NULL)
+        return;
+
+    QModelIndexList indexesOfSelectedRows = tableView->selectionModel()->selectedRows();
+
+    m_SelectedDomainsIndex=-1;
+
+    if(indexesOfSelectedRows.size()==0)
+    {
+        mitk::RenderingManager::GetInstance()->RequestUpdateAll();
+        return;
+    }
+
+    int row=indexesOfSelectedRows[0].row();
+    m_SelectedDomainsIndex=row;
+
+    QStandardItem* itemShape= tableModel->item(row,0);
+    QString shape=itemShape->text();
+
+    QStandardItem* itemLocal= tableModel->item(row,1);
+    QString localSize=itemLocal->text();
+
+    mitk::RenderingManager::GetInstance()->RequestUpdateAll();
+}
+
 void svMeshEdit::SetRegion(bool)
 {
     if(!m_Model)
@@ -416,6 +478,38 @@ void svMeshEdit::DeleteSelectedRegions(bool)
 
     QStandardItemModel* tableModel=m_TableModelRegion;
     QTableView* tableView=ui->tableViewRegion;
+
+    if(tableModel==NULL || tableView==NULL)
+        return;
+
+    QModelIndexList indexesOfSelectedRows = tableView->selectionModel()->selectedRows();
+    if(indexesOfSelectedRows.size() < 1)
+    {
+      return;
+    }
+
+    std::vector<int> rows;
+    for(int i=0;i<indexesOfSelectedRows.size();i++)
+        rows.push_back(indexesOfSelectedRows[i].row());
+
+    std::sort(rows.begin(), rows.end(), std::greater<int>());
+
+    for(int i=0;i<rows.size();i++)
+        tableModel->removeRow(rows[i]);
+
+}
+
+void svMeshEdit::DeleteSelectedDomains(bool)
+{
+    if(!m_Model)
+        return;
+
+    int timeStep=GetTimeStep();
+    svModelElement* modelElement=m_Model->GetModelElement(timeStep);
+    if(modelElement==NULL) return;
+
+    QStandardItemModel* tableModel=m_TableModelDomains;
+    QTableView* tableView=ui->tableViewDomains;
 
     if(tableModel==NULL || tableView==NULL)
         return;
@@ -702,6 +796,20 @@ std::vector<std::string> svMeshEdit::CreateCmdsT()
 
     if(ui->checkBoxFlagV->isChecked())
         cmds.push_back("option Verbose");
+
+    for(int i=0;i<m_TableModelDomains->rowCount();i++)
+    {
+        QStandardItem* itemType= m_TableModelDomains->item(i,0);
+        QString type=itemType->text();
+
+        QStandardItem* itemParams= m_TableModelDomains->item(i,1);
+        QString params=itemParams->text();
+        QStringList plist = params.split(QRegExp("\\s+"));
+
+        if(!plist.isEmpty())
+            cmds.push_back("option AddHole " + plist[0].toStdString()
+                    + " " + plist[1].toStdString() + " " + plist[2].toStdString());
+    }
 
     cmds.push_back("generateMesh");
 
@@ -1117,6 +1225,18 @@ void svMeshEdit::UpdateTetGenGUI()
     ui->tableViewRegion->horizontalHeader()->resizeSection(1,80);
     ui->tableViewRegion->horizontalHeader()->setSectionResizeMode(2, QHeaderView::Interactive);
 
+    //multi-domain region
+    m_TableModelDomains->clear();
+
+    QStringList domainsListHeaders;
+    domainsListHeaders << "Type" << "Location x y z";
+    m_TableModelDomains->setHorizontalHeaderLabels(domainsListHeaders);
+    m_TableModelDomains->setColumnCount(2);
+
+    ui->tableViewDomains->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Fixed);
+    ui->tableViewDomains->horizontalHeader()->resizeSection(0,80);;
+    ui->tableViewDomains->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Interactive);
+
     //advanced flags
     ui->checkBoxFlagO->setChecked(true);
     ui->sliderFlagO->setValue(3);
@@ -1147,6 +1267,7 @@ void svMeshEdit::UpdateTetGenGUI()
     bool option=false;
     std::string msg="";
     int regionRowIndex=-1;
+    int domainsRowIndex=-1;
 
     if(cmdHistory.size()>0)
         ui->checkBoxFastMeshing->setChecked(true);
@@ -1268,6 +1389,20 @@ void svMeshEdit::UpdateTetGenGUI()
             item= new QStandardItem(QString::number(values[1])+" "+QString::number(values[2])+" "+QString::number(values[3])+" "+QString::number(values[4]));
             item->setEditable(false);
             m_TableModelRegion->setItem(regionRowIndex, 2, item);
+        }
+        else if (flag=="AddHole")
+        {
+          domainsRowIndex++;
+          m_TableModelDomains->insertRow(domainsRowIndex);
+
+          QStandardItem* item;
+
+          item= new QStandardItem("Hole");
+          item->setEditable(false);
+          m_TableModelDomains->setItem(domainsRowIndex, 0, item);
+
+          item= new QStandardItem(QString::number(values[1])+" "+QString::number(values[2])+" "+QString::number(values[3]));
+          m_TableModelDomains->setItem(domainsRowIndex, 1, item);
         }
         else
         {
@@ -1634,6 +1769,20 @@ void svMeshEdit::AddSphere()
     m_SphereWidget->GetCenter(center);
     item= new QStandardItem(QString::number(m_SphereWidget->GetRadius())+" "+QString::number(center[0])+" "+QString::number(center[1])+" "+QString::number(center[2]));
     m_TableModelRegion->setItem(regionRowIndex, 2, item);
+}
+
+void svMeshEdit::AddHole()
+{
+    int regionRowIndex=m_TableModelDomains->rowCount();
+
+    QStandardItem* item;
+
+    item= new QStandardItem("Hole");
+    item->setEditable(false);
+    m_TableModelDomains->setItem(regionRowIndex, 0, item);
+
+    item= new QStandardItem("0.0 0.0 0.0");
+    m_TableModelDomains->setItem(regionRowIndex, 1, item);
 }
 
 void svMeshEdit::ShowSphereInteractor(bool checked)

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.h
@@ -58,6 +58,10 @@ public slots:
 
     void TableRegionListSelectionChanged( const QItemSelection & selected, const QItemSelection & deselected );
 
+    void TableDomainsListSelectionChanged( const QItemSelection & selected, const QItemSelection & deselected );
+
+    void DeleteSelectedDomains( bool checked = false );
+
     void SetRegion( bool checked = false );
 
     void DeleteSelectedRegions( bool checked = false );
@@ -73,6 +77,8 @@ public slots:
     void UpdateAdaptGUI(int selected);
 
     void AddSphere();
+
+    void AddHole();
 
     void ShowSphereInteractor(bool checked);
 
@@ -155,7 +161,11 @@ protected:
     QMenu* m_TableMenuRegion;
     QStandardItemModel* m_TableModelRegion;
 
+    QMenu* m_TableMenuDomains;
+    QStandardItemModel* m_TableModelDomains;
+
     int m_SelectedRegionIndex;
+    int m_SelectedDomainsIndex;
 
     vtkSmartPointer<vtkSphereWidget> m_SphereWidget;
 

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.h
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.h
@@ -62,11 +62,15 @@ public slots:
 
     void DeleteSelectedDomains( bool checked = false );
 
+    void SetSubDomainSize( bool checked = false );
+
     void SetRegion( bool checked = false );
 
     void DeleteSelectedRegions( bool checked = false );
 
     void TableViewRegionContextMenuRequested( const QPoint & pos );
+
+    void TableViewDomainsContextMenuRequested( const QPoint & pos );
 
     void UpdateFaceListSelection();
 
@@ -79,6 +83,8 @@ public slots:
     void AddSphere();
 
     void AddHole();
+
+    void AddSubDomain();
 
     void ShowSphereInteractor(bool checked);
 

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
@@ -334,8 +334,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>544</height>
+              <width>324</width>
+              <height>320</height>
              </rect>
             </property>
             <attribute name="label">
@@ -903,8 +903,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>544</height>
+              <width>98</width>
+              <height>84</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -1106,8 +1106,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>544</height>
+              <width>323</width>
+              <height>196</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1356,8 +1356,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>544</height>
+              <width>231</width>
+              <height>303</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1771,14 +1771,30 @@
               <widget class="QWidget" name="verticalWidget" native="true">
                <layout class="QHBoxLayout" name="horizontalLayout_25">
                 <item>
-                 <widget class="QTableView" name="tableViewDomains"/>
+                 <widget class="QTableView" name="tableViewDomains">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="contextMenuPolicy">
+                   <enum>Qt::CustomContextMenu</enum>
+                  </property>
+                  <property name="selectionMode">
+                   <enum>QAbstractItemView::ExtendedSelection</enum>
+                  </property>
+                  <property name="selectionBehavior">
+                   <enum>QAbstractItemView::SelectRows</enum>
+                  </property>
+                 </widget>
                 </item>
                 <item>
                  <layout class="QVBoxLayout" name="verticalLayout_23">
                   <item>
                    <widget class="QLabel" name="labelAddSubDomain">
                     <property name="text">
-                     <string>Add SumDomain:</string>
+                     <string>Add SubDomain:</string>
                     </property>
                    </widget>
                   </item>

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
@@ -327,15 +327,15 @@
          <item>
           <widget class="QToolBox" name="toolBox">
            <property name="currentIndex">
-            <number>4</number>
+            <number>5</number>
            </property>
            <widget class="QWidget" name="page_3">
             <property name="geometry">
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>584</height>
+              <width>320</width>
+              <height>320</height>
              </rect>
             </property>
             <attribute name="label">
@@ -828,17 +828,17 @@
                     </widget>
                    </item>
                    <item>
-                    <widget class="ctkSliderWidget" name="sliderPassesM">
-                     <property name="decimals">
+                    <widget class="ctkSliderWidget" name="sliderPassesM" native="true">
+                     <property name="decimals" stdset="0">
                       <number>0</number>
                      </property>
-                     <property name="pageStep">
+                     <property name="pageStep" stdset="0">
                       <double>1.000000000000000</double>
                      </property>
-                     <property name="maximum">
+                     <property name="maximum" stdset="0">
                       <double>20.000000000000000</double>
                      </property>
-                     <property name="value">
+                     <property name="value" stdset="0">
                       <double>3.000000000000000</double>
                      </property>
                     </widget>
@@ -903,8 +903,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>584</height>
+              <width>100</width>
+              <height>84</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -988,8 +988,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>584</height>
+              <width>167</width>
+              <height>84</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1106,8 +1106,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>584</height>
+              <width>322</width>
+              <height>196</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1176,23 +1176,23 @@
                     </widget>
                    </item>
                    <item>
-                    <widget class="ctkSliderWidget" name="sliderFlagO">
-                     <property name="decimals">
+                    <widget class="ctkSliderWidget" name="sliderFlagO" native="true">
+                     <property name="decimals" stdset="0">
                       <number>0</number>
                      </property>
-                     <property name="pageStep">
+                     <property name="pageStep" stdset="0">
                       <double>1.000000000000000</double>
                      </property>
-                     <property name="minimum">
+                     <property name="minimum" stdset="0">
                       <double>1.000000000000000</double>
                      </property>
-                     <property name="maximum">
+                     <property name="maximum" stdset="0">
                       <double>7.000000000000000</double>
                      </property>
-                     <property name="value">
+                     <property name="value" stdset="0">
                       <double>3.000000000000000</double>
                      </property>
-                     <property name="tickInterval">
+                     <property name="tickInterval" stdset="0">
                       <double>1.000000000000000</double>
                      </property>
                     </widget>
@@ -1229,23 +1229,23 @@
                     </widget>
                    </item>
                    <item>
-                    <widget class="ctkSliderWidget" name="sliderFlagQ">
-                     <property name="decimals">
+                    <widget class="ctkSliderWidget" name="sliderFlagQ" native="true">
+                     <property name="decimals" stdset="0">
                       <number>1</number>
                      </property>
-                     <property name="singleStep">
+                     <property name="singleStep" stdset="0">
                       <double>0.100000000000000</double>
                      </property>
-                     <property name="pageStep">
+                     <property name="pageStep" stdset="0">
                       <double>0.500000000000000</double>
                      </property>
-                     <property name="minimum">
+                     <property name="minimum" stdset="0">
                       <double>1.100000000000000</double>
                      </property>
-                     <property name="maximum">
+                     <property name="maximum" stdset="0">
                       <double>2.000000000000000</double>
                      </property>
-                     <property name="value">
+                     <property name="value" stdset="0">
                       <double>1.400000000000000</double>
                      </property>
                     </widget>
@@ -1356,8 +1356,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>489</width>
-              <height>584</height>
+              <width>227</width>
+              <height>303</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1751,6 +1751,79 @@
                 </size>
                </property>
               </spacer>
+             </item>
+            </layout>
+           </widget>
+           <widget class="QWidget" name="page_10">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>489</width>
+              <height>544</height>
+             </rect>
+            </property>
+            <attribute name="label">
+             <string>Multi-Domain</string>
+            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_26">
+             <item>
+              <widget class="QWidget" name="verticalWidget" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_25">
+                <item>
+                 <widget class="QTableView" name="tableViewDomains"/>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="verticalLayout_23">
+                  <item>
+                   <widget class="QLabel" name="labelAddHoleLabel">
+                    <property name="maximumSize">
+                     <size>
+                      <width>80</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Add Hole:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="btnAddHole">
+                    <property name="maximumSize">
+                     <size>
+                      <width>100</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Add</string>
+                    </property>
+                    <property name="iconSize">
+                     <size>
+                      <width>16</width>
+                      <height>16</height>
+                     </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="verticalSpacer_5">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
              </item>
             </layout>
            </widget>

--- a/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
+++ b/Code/Source/Plugins/org.sv.gui.qt.meshing/src/internal/svMeshEdit.ui
@@ -334,8 +334,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>320</width>
-              <height>320</height>
+              <width>489</width>
+              <height>544</height>
              </rect>
             </property>
             <attribute name="label">
@@ -903,8 +903,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>100</width>
-              <height>84</height>
+              <width>489</width>
+              <height>544</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -988,8 +988,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>167</width>
-              <height>84</height>
+              <width>489</width>
+              <height>544</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1106,8 +1106,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>322</width>
-              <height>196</height>
+              <width>489</width>
+              <height>544</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1356,8 +1356,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>227</width>
-              <height>303</height>
+              <width>489</width>
+              <height>544</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1776,10 +1776,24 @@
                 <item>
                  <layout class="QVBoxLayout" name="verticalLayout_23">
                   <item>
+                   <widget class="QLabel" name="labelAddSubDomain">
+                    <property name="text">
+                     <string>Add SumDomain:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="btnAddSubDomain">
+                    <property name="text">
+                     <string>Add</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QLabel" name="labelAddHoleLabel">
                     <property name="maximumSize">
                      <size>
-                      <width>80</width>
+                      <width>16777215</width>
                       <height>16777215</height>
                      </size>
                     </property>
@@ -1792,7 +1806,7 @@
                    <widget class="QPushButton" name="btnAddHole">
                     <property name="maximumSize">
                      <size>
-                      <width>100</width>
+                      <width>16777215</width>
                       <height>16777215</height>
                      </size>
                     </property>


### PR DESCRIPTION
Implements meshing for holes and subdomains using tetgen.

Right now, the most basic way of incorporating both of these features is implemented. A 3d coordinate is given to indicate a hole or subdomain lying strictly within a surface. Input surfaces with more than one connected region and non-manifold edges are now allowed for these types of meshes. 