### PR TITLE
2018 06 12 try bl as multi domain

### DIFF
--- a/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.cxx
+++ b/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.cxx
@@ -128,12 +128,14 @@ cvTetGenMeshObject::cvTetGenMeshObject(Tcl_Interp *interp)
   meshoptions_.maxedgesize=0;
   meshoptions_.epsilon=0;
   meshoptions_.minratio=0;
-  meshoptions_.coarsen_percent=0;
+  meshoptions_.coarsenpercent=0;
   meshoptions_.boundarylayermeshflag=0;
   meshoptions_.numsublayers=0;
   meshoptions_.blthicknessfactor=0;
   meshoptions_.sublayerratio=0;
   meshoptions_.useconstantblthickness=0;
+  meshoptions_.newregionboundarylayer=0;
+  meshoptions_.boundarylayerinward=1;
   meshoptions_.refinement=0;
   meshoptions_.refinedsize=0;
   meshoptions_.sphereradius=0;
@@ -170,74 +172,77 @@ cvTetGenMeshObject::cvTetGenMeshObject(Tcl_Interp *interp)
 cvTetGenMeshObject::cvTetGenMeshObject()
 : cvMeshObject()
 {
-inmesh_ = NULL;
-outmesh_ = NULL;
-polydatasolid_ = NULL;
-inputug_ = NULL;
-meshloaded_ = 0;
-loadedVolumeMesh_ = 0;
-//nodemap_ = NULL;
-pts_ = NULL;
+  inmesh_ = NULL;
+  outmesh_ = NULL;
+  polydatasolid_ = NULL;
+  inputug_ = NULL;
+  meshloaded_ = 0;
+  loadedVolumeMesh_ = 0;
+  //nodemap_ = NULL;
+  pts_ = NULL;
 
-originalpolydata_ = NULL;
-surfacemesh_ = NULL;
-volumemesh_ = NULL;
-boundarylayermesh_ = NULL;
-innerblmesh_ = NULL;
-holelist_ = NULL;
-regionlist_ = NULL;
-regionsizelist_ = NULL;
+  originalpolydata_ = NULL;
+  surfacemesh_ = NULL;
+  volumemesh_ = NULL;
+  boundarylayermesh_ = NULL;
+  innerblmesh_ = NULL;
+  holelist_ = NULL;
+  regionlist_ = NULL;
+  regionsizelist_ = NULL;
 
-meshFileName_[0] = '\0';
-solidFileName_[0] = '\0';
+  meshFileName_[0] = '\0';
+  solidFileName_[0] = '\0';
 
-solidmodeling_kernel_ = SM_KT_POLYDATA;
-numModelRegions_ = 0;
-numBoundaryRegions_ = 0;
+  solidmodeling_kernel_ = SM_KT_POLYDATA;
+  numModelRegions_ = 0;
+  numBoundaryRegions_ = 0;
 
-//All the different mesh options. Originally set to zero. Changed by calls to object from GUI
-//Specifically ->SetMeshOptions()
-meshoptions_.surfacemeshflag=0;
-meshoptions_.volumemeshflag=0;
-meshoptions_.nomerge=0;
-meshoptions_.quiet=0;
-meshoptions_.docheck=0;
-meshoptions_.verbose=0;
-meshoptions_.diagnose=0;
-meshoptions_.nobisect=0;
-meshoptions_.optlevel=0;
-meshoptions_.maxedgesize=0;
-meshoptions_.epsilon=0;
-meshoptions_.minratio=0;
-meshoptions_.coarsen_percent=0;
-meshoptions_.boundarylayermeshflag=0;
-meshoptions_.numsublayers=0;
-meshoptions_.blthicknessfactor=0;
-meshoptions_.sublayerratio=0;
-meshoptions_.refinement=0;
-meshoptions_.refinedsize=0;
-meshoptions_.sphereradius=0;
-meshoptions_.cylinderradius=0;
-meshoptions_.cylinderlength=0;
-meshoptions_.functionbasedmeshing=0;
-meshoptions_.secondarrayfunction=0;
-meshoptions_.meshwallfirst=0;
-meshoptions_.startwithvolume=0;
-meshoptions_.refinecount=0;
-meshoptions_.numberofholes=0;
-meshoptions_.numberofregions=0;
+  //All the different mesh options. Originally set to zero. Changed by calls to object from GUI
+  //Specifically ->SetMeshOptions()
+  meshoptions_.surfacemeshflag=0;
+  meshoptions_.volumemeshflag=0;
+  meshoptions_.nomerge=0;
+  meshoptions_.quiet=0;
+  meshoptions_.docheck=0;
+  meshoptions_.verbose=0;
+  meshoptions_.diagnose=0;
+  meshoptions_.nobisect=0;
+  meshoptions_.optlevel=0;
+  meshoptions_.maxedgesize=0;
+  meshoptions_.epsilon=0;
+  meshoptions_.minratio=0;
+  meshoptions_.coarsenpercent=0;
+  meshoptions_.boundarylayermeshflag=0;
+  meshoptions_.numsublayers=0;
+  meshoptions_.blthicknessfactor=0;
+  meshoptions_.sublayerratio=0;
+  meshoptions_.useconstantblthickness=0;
+  meshoptions_.newregionboundarylayer=0;
+  meshoptions_.boundarylayerinward=1;
+  meshoptions_.refinement=0;
+  meshoptions_.refinedsize=0;
+  meshoptions_.sphereradius=0;
+  meshoptions_.cylinderradius=0;
+  meshoptions_.cylinderlength=0;
+  meshoptions_.functionbasedmeshing=0;
+  meshoptions_.secondarrayfunction=0;
+  meshoptions_.meshwallfirst=0;
+  meshoptions_.startwithvolume=0;
+  meshoptions_.refinecount=0;
+  meshoptions_.numberofholes=0;
+  meshoptions_.numberofregions=0;
 #ifdef SV_USE_MMG
-meshoptions_.usemmg=1;
+  meshoptions_.usemmg=1;
 #else
-meshoptions_.usemmg=0;
+  meshoptions_.usemmg=0;
 #endif
-meshoptions_.hausd=0;
-for (int i=0;i<3;i++)
-{
-  meshoptions_.spherecenter[i] = 0;
-  meshoptions_.cylindercenter[i] = 0;
-  meshoptions_.cylindernormal[i] = 0;
-}
+  meshoptions_.hausd=0;
+  for (int i=0;i<3;i++)
+  {
+    meshoptions_.spherecenter[i] = 0;
+    meshoptions_.cylindercenter[i] = 0;
+    meshoptions_.cylindernormal[i] = 0;
+  }
 }
 #endif
 // -----------
@@ -1014,30 +1019,30 @@ int cvTetGenMeshObject::NewMesh() {
 
 int cvTetGenMeshObject::SetMeshOptions(char *flags,int numValues,double *values) {
   if(!strncmp(flags,"GlobalEdgeSize",14)) {            //Global edge size
-       if (numValues < 1)
-   return SV_ERROR;
+     if (numValues < 1)
+       return SV_ERROR;
 
-      meshoptions_.maxedgesize=values[0];
+    meshoptions_.maxedgesize=values[0];
   }
   else if(!strncmp(flags,"LocalEdgeSize",13)) {
 
-      if (numValues < 2)
-      {
-	fprintf(stderr,"Must give face id and local edge size\n");
-	return SV_ERROR;
-      }
-      meshoptions_.functionbasedmeshing = 1;
-      //Create a new mesh sizing function and call TGenUtils to compute function.
-      //Store in the member data vtkDouble Array meshsizingfunction
-      if (TGenUtils_SetLocalMeshSize(polydatasolid_,values[0],values[1]) != SV_OK)
-        return SV_ERROR;
-      meshoptions_.secondarrayfunction = 1;
+    if (numValues < 2)
+    {
+      fprintf(stderr,"Must give face id and local edge size\n");
+      return SV_ERROR;
+    }
+    meshoptions_.functionbasedmeshing = 1;
+    //Create a new mesh sizing function and call TGenUtils to compute function.
+    //Store in the member data vtkDouble Array meshsizingfunction
+    if (TGenUtils_SetLocalMeshSize(polydatasolid_,values[0],values[1]) != SV_OK)
+      return SV_ERROR;
+    meshoptions_.secondarrayfunction = 1;
   }
   else if(!strncmp(flags,"SurfaceMeshFlag",15)) {
 #ifdef SV_USE_VMTK
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.surfacemeshflag = values[0];
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.surfacemeshflag = values[0];
 #else
       fprintf(stderr,"Plugin VMTK is not being used!\
 	  In order to use surface meshing, plugin VMTK must be available!\n");
@@ -1045,29 +1050,29 @@ int cvTetGenMeshObject::SetMeshOptions(char *flags,int numValues,double *values)
 #endif
   }
   else if(!strncmp(flags,"VolumeMeshFlag",14)) {
-      if (numValues < 1)
-  return SV_ERROR;
-      meshoptions_.volumemeshflag = values[0];
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.volumemeshflag = values[0];
   }
   else if(!strncmp(flags,"QualityRatio",12)) {//q
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.minratio=values[0];
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.minratio=values[0];
   }
   else if(!strncmp(flags,"Optimization",12)) {//O
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.optlevel=(int)values[0];
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.optlevel=(int)values[0];
   }
   else if(!strncmp(flags,"Epsilon",7)) {//T
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.epsilon=values[0];
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.epsilon=values[0];
   }
   else if(!strncmp(flags,"CoarsenPercent",14)) {//R
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.coarsen_percent=values[0]/100;
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.coarsenpercent=values[0]/100;
   }
   else if(!strncmp(flags,"AddHole",7)) {
     if (numValues < 3)
@@ -1096,38 +1101,46 @@ int cvTetGenMeshObject::SetMeshOptions(char *flags,int numValues,double *values)
 
   }
   else if(!strncmp(flags,"Verbose",7)) {//V
-      meshoptions_.verbose=1;
+    meshoptions_.verbose=1;
   }
   else if(!strncmp(flags,"NoMerge",7)) {//M
-      meshoptions_.nomerge=1;
+    meshoptions_.nomerge=1;
   }
   else if(!strncmp(flags,"Check",5)) {//C
-      meshoptions_.docheck=1;
+    meshoptions_.docheck=1;
   }
   else if(!strncmp(flags,"NoBisect",8)) {//Y
-      meshoptions_.nobisect=1;
+    meshoptions_.nobisect=1;
   }
   else if(!strncmp(flags,"Quiet",5)) {//Q
-      meshoptions_.quiet=1;
+    meshoptions_.quiet=1;
   }
   else if(!strncmp(flags,"Diagnose",8)) {//d
-      meshoptions_.diagnose=1;
+    meshoptions_.diagnose=1;
   }
   else if(!strncmp(flags,"MeshWallFirst",13)) {//k
-      meshoptions_.meshwallfirst=1;
+    meshoptions_.meshwallfirst=1;
   }
   else if(!strncmp(flags,"StartWithVolume",15)) {//r
-      meshoptions_.startwithvolume=1;
+    meshoptions_.startwithvolume=1;
   }
-  else if(!strncmp(flags,"Hausd",5)) {//r
-      if (numValues < 1)
-	return SV_ERROR;
-      meshoptions_.hausd=values[0];
+  else if(!strncmp(flags,"Hausd",5)) {
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.hausd=values[0];
   }
   else if (!strncmp(flags,"UseMMG",6)){
       if (numValues < 1)
-	return SV_ERROR;
+        return SV_ERROR;
       meshoptions_.usemmg=values[0];
+  }
+  else if (!strncmp(flags,"NewRegionBoundaryLayer",22)) {
+    meshoptions_.newregionboundarylayer=1;
+  }
+  else if (!strncmp(flags,"BoundaryLayerInward",19)) {
+    if (numValues < 1)
+      return SV_ERROR;
+    meshoptions_.boundarylayerinward=values[0];
   }
   else {
       fprintf(stderr,"%s: flag is not recognized\n",flags);
@@ -1534,10 +1547,10 @@ int cvTetGenMeshObject::GenerateMesh() {
       tgb->regionattrib = 1;
     }
 #if defined(TETGEN150) || defined(TETGEN151)
-    if (meshoptions_.coarsen_percent != 0)
+    if (meshoptions_.coarsenpercent != 0)
     {
       tgb->coarsen=1;
-      tgb->coarsen_percent=meshoptions_.coarsen_percent;
+      tgb->coarsen_percent=meshoptions_.coarsenpercent;
     }
     if (meshoptions_.nomerge)
     {
@@ -1939,10 +1952,6 @@ int cvTetGenMeshObject::GenerateBoundaryLayerMesh()
     fprintf(stderr,"Problem when computing sizing function");
     return SV_ERROR;
   }
-  vtkSmartPointer<vtkXMLPolyDataWriter> writer = vtkSmartPointer<vtkXMLPolyDataWriter>::New();
-  writer->SetInputData(cleanpd);
-  writer->SetFileName("/Users/adamupdegrove/Desktop/tmp/WHATHTE.vtp");
-  writer->Write();
 
   converter->SetInputData(cleanpd);
   converter->Update();
@@ -2153,9 +2162,10 @@ int cvTetGenMeshObject::AppendBoundaryLayerMesh()
 
   //We append the volume mesh from tetgen, the inner surface, and the
   //boundary layer mesh all together.
+  int newregionboundarylayer = meshoptions_.newregionboundarylayer;
   fprintf(stdout,"Appending Boundary Layer and Volume Mesh\n");
   if (VMTKUtils_AppendMesh(volumemesh_,innerblmesh_,boundarylayermesh_,
-    surfacetomesh->GetOutput(),markerListName) != SV_OK)
+    surfacetomesh->GetOutput(),markerListName, newregionboundarylayer) != SV_OK)
   {
   return SV_ERROR;
   }
@@ -2242,7 +2252,7 @@ int cvTetGenMeshObject::Adapt()
   newtgb->verbose=1;
   //newtgb->coarsen=1;
   //newtgb->coarsen_param=8;
-  //newtgb->coarsen_percent=1;
+  //newtgb->coarsenpercent=1;
 #if USE_TETGEN143
   newtgb->goodratio = 4.0;
   newtgb->goodangle = 0.88;

--- a/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.h
+++ b/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.h
@@ -71,12 +71,14 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
     double maxedgesize;
     double epsilon;
     double minratio;
-    double coarsen_percent;
+    double coarsenpercent;
     int boundarylayermeshflag;
     int numsublayers;
     double blthicknessfactor;
     double sublayerratio;
     int useconstantblthickness;
+    int newregionboundarylayer;
+    int boundarylayerinward;
     int refinement;
     double refinedsize;
     double sphereradius;

--- a/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.h
+++ b/Code/Source/sv/Mesh/TetGenMeshObject/sv_TetGenMeshObject.h
@@ -78,7 +78,7 @@ class SV_EXPORT_TETGEN_MESH cvTetGenMeshObject : public cvMeshObject {
     double sublayerratio;
     int useconstantblthickness;
     int newregionboundarylayer;
-    int boundarylayerinward;
+    int boundarylayerdirection;
     int refinement;
     double refinedsize;
     double sphereradius;

--- a/Code/Source/sv/Mesh/VMTKUtils/sv_vmtk_utils.h
+++ b/Code/Source/sv/Mesh/VMTKUtils/sv_vmtk_utils.h
@@ -93,7 +93,8 @@ SV_EXPORT_VMTK_UTILS int VMTKUtils_BoundaryLayerMesh(vtkUnstructuredGrid *blMesh
 SV_EXPORT_VMTK_UTILS int VMTKUtils_AppendMesh(vtkUnstructuredGrid *meshFromTetGen,
     vtkUnstructuredGrid *innerMesh, vtkUnstructuredGrid *boundaryMesh,
     vtkUnstructuredGrid *surfaceWithSize,
-    std::string cellEntityIdsArrayName);
+    std::string cellEntityIdsArrayName,
+    int newRegionBoundaryLayer);
 
 SV_EXPORT_VMTK_UTILS int VMTKUtils_InsertIds(vtkUnstructuredGrid *fullmesh, vtkPolyData *fullpolydata);
 

--- a/Code/Source/sv4gui/Modules/Mesh/Common/sv4gui_MeshTetGen.cxx
+++ b/Code/Source/sv4gui/Modules/Mesh/Common/sv4gui_MeshTetGen.cxx
@@ -355,6 +355,11 @@ bool sv4guiMeshTetGen::ParseCommand(std::string cmd, std::string& flag, double v
             values[2]=std::stod(params[3]);
             values[3]=std::stod(params[4]);
         }
+        else if(params[0]=="newregionboundarylayer")
+        {
+          flag="NewRegionBoundaryLayer";
+          option=true;
+        }
         else if(paramSize==3 && (params[0]=="localedgesize" || params[0]=="localsize"))
         {
             flag="LocalEdgeSize";

--- a/Code/Source/sv4gui/Modules/Mesh/Common/sv4gui_MeshTetGen.cxx
+++ b/Code/Source/sv4gui/Modules/Mesh/Common/sv4gui_MeshTetGen.cxx
@@ -360,6 +360,12 @@ bool sv4guiMeshTetGen::ParseCommand(std::string cmd, std::string& flag, double v
           flag="NewRegionBoundaryLayer";
           option=true;
         }
+        else if(paramSize==2 && params[0]=="boundarylayerdirection")
+        {
+          flag="BoundaryLayerDirection";
+          values[0]=std::stod(params[1]);
+          option=true;
+        }
         else if(paramSize==3 && (params[0]=="localedgesize" || params[0]=="localsize"))
         {
             flag="LocalEdgeSize";

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
@@ -820,7 +820,7 @@ std::vector<std::string> sv4guiMeshEdit::CreateCmdsT()
     else
         cmds.push_back("option volume 0");
 
-    if(ui->checkBoxRadiusBasedT->isChecked() || ui->checkBoxBoundaryLayerT->isChecked())
+    if(ui->checkBoxRadiusBasedT->isChecked())
     {
         cmds.push_back("option UseMMG 0");
         ui->checkBoxFastMeshing->setChecked(false);

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
@@ -846,13 +846,17 @@ std::vector<std::string> sv4guiMeshEdit::CreateCmdsT()
       int useConstantThickness = ui->checkBoxConstantThicknessBL->isChecked();
       cmds.push_back("boundaryLayer "+QString::number(ui->sbLayersT->value()).toStdString()
                        +" "+QString::number(ui->dsbPortionT->value()).toStdString()+" "+QString::number(ui->dsbRatioT->value()).toStdString()+" "+QString::number(useConstantThickness).toStdString());
+
+      int boundaryLayerDirection = ui->checkBoxBoundaryLayerDirection->isChecked();
+      cmds.push_back("option BoundaryLayerDirection "+QString::number(boundaryLayerDirection).toStdString());
+
+      if (ui->checkBoxConvertBLToNewRegion->isChecked())
+      {
+        int convertBLToNewRegion = ui->checkBoxConvertBLToNewRegion->isChecked();
+        cmds.push_back("option NewRegionBoundaryLayer");
+      }
     }
 
-    if (ui->checkBoxConvertBLToNewRegion->isChecked())
-    {
-      int convertBLToNewRegion = ui->checkBoxConvertBLToNewRegion->isChecked();
-      cmds.push_back("option NewRegionBoundaryLayer");
-    }
 
     for(int i=0;i<m_TableModelLocal->rowCount();i++)
     {
@@ -1567,6 +1571,14 @@ void sv4guiMeshEdit::UpdateTetGenGUI()
 
           item= new QStandardItem(QString::number(values[1])+" "+QString::number(values[2])+" "+QString::number(values[3]));
           m_TableModelDomains->setItem(domainsRowIndex, 2, item);
+        }
+        else if (flag == "NewRegionBoundaryLayer")
+        {
+          ui->checkBoxConvertBLToNewRegion->setChecked(true);
+        }
+        else if (flag == "BoundaryLayerDirection")
+        {
+          ui->checkBoxBoundaryLayerDirection->setChecked(true);
         }
         else
         {

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.cxx
@@ -848,6 +848,12 @@ std::vector<std::string> sv4guiMeshEdit::CreateCmdsT()
                        +" "+QString::number(ui->dsbPortionT->value()).toStdString()+" "+QString::number(ui->dsbRatioT->value()).toStdString()+" "+QString::number(useConstantThickness).toStdString());
     }
 
+    if (ui->checkBoxConvertBLToNewRegion->isChecked())
+    {
+      int convertBLToNewRegion = ui->checkBoxConvertBLToNewRegion->isChecked();
+      cmds.push_back("option NewRegionBoundaryLayer");
+    }
+
     for(int i=0;i<m_TableModelLocal->rowCount();i++)
     {
         QStandardItem* itemName= m_TableModelLocal->item(i,1);

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.ui
@@ -549,6 +549,16 @@
                     </widget>
                    </item>
                    <item>
+                    <widget class="QCheckBox" name="checkBoxBoundaryLayerDirection">
+                     <property name="text">
+                      <string>Extrude Bounary Layer Inward from Wall</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
                     <widget class="QCheckBox" name="checkBoxConstantThicknessBL">
                      <property name="toolTip">
                       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If selected, the same boundary layer thickness will be used throughout the entire model. If left unselected, the boundary layer thickness will scale with the local mesh edge size.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -939,8 +949,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>467</width>
-              <height>547</height>
+              <width>100</width>
+              <height>84</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -1034,8 +1044,8 @@ Press key &quot;S&quot; outside of any face to deselect all faces.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>467</width>
-              <height>547</height>
+              <width>167</width>
+              <height>84</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1159,8 +1169,8 @@ Change size: righ click and hold, move.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>467</width>
-              <height>547</height>
+              <width>323</width>
+              <height>196</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1409,8 +1419,8 @@ Change size: righ click and hold, move.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>467</width>
-              <height>547</height>
+              <width>237</width>
+              <height>84</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1533,8 +1543,8 @@ Click the button to add it to the left table.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>467</width>
-              <height>547</height>
+              <width>231</width>
+              <height>303</height>
              </rect>
             </property>
             <attribute name="label">

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.meshing/sv4gui_MeshEdit.ui
@@ -558,6 +558,16 @@
                      </property>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QCheckBox" name="checkBoxConvertBLToNewRegion">
+                     <property name="text">
+                      <string>Convert Boundary Layer to New Region/Domain</string>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
                   </layout>
                  </widget>
                 </item>
@@ -929,8 +939,8 @@
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>98</width>
-              <height>84</height>
+              <width>467</width>
+              <height>547</height>
              </rect>
             </property>
             <property name="sizePolicy">
@@ -1024,8 +1034,8 @@ Press key &quot;S&quot; outside of any face to deselect all faces.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>167</width>
-              <height>84</height>
+              <width>467</width>
+              <height>547</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1149,8 +1159,8 @@ Change size: righ click and hold, move.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>323</width>
-              <height>196</height>
+              <width>467</width>
+              <height>547</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1399,8 +1409,8 @@ Change size: righ click and hold, move.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>237</width>
-              <height>84</height>
+              <width>467</width>
+              <height>547</height>
              </rect>
             </property>
             <attribute name="label">
@@ -1523,8 +1533,8 @@ Click the button to add it to the left table.</string>
              <rect>
               <x>0</x>
               <y>0</y>
-              <width>231</width>
-              <height>303</height>
+              <width>467</width>
+              <height>547</height>
              </rect>
             </property>
             <attribute name="label">


### PR DESCRIPTION
Makes it possible to extrude the boundary layer either inward or outward.
Also makes it possible to label the boundary layer with different ModelRegionID.
Additionally updates boundary layer meshing to use mmg for original surface remeshing rather than vmtk.