### PR TITLE
Remove 3d seg

### DIFF
--- a/Code/Source/sv4gui/Modules/svFSI/sv4gui_svFSIJob.cxx
+++ b/Code/Source/sv4gui/Modules/svFSI/sv4gui_svFSIJob.cxx
@@ -232,7 +232,7 @@ bool sv4guisvFSIJob::WriteFile(std::string filePath)
         if(eq.physName!="mesh")
         {
             out << tabS << "LS type: " << eq.lsType << " {" << endL;
-            if(eq.lsPreconditioner!="")
+            if(eq.lsPreconditioner!="" && eq.lsPreconditioner!="Default")
                 out << tabS << tabS << "Preconditioner: " <<eq.lsPreconditioner << endL;
 
             out << tabS << tabS << "Max iterations: " <<eq.lsMaxItr << endL;

--- a/Code/Source/sv4gui/Modules/svFSI/sv4gui_svFSIeqClass.cxx
+++ b/Code/Source/sv4gui/Modules/svFSI/sv4gui_svFSIeqClass.cxx
@@ -123,7 +123,8 @@ sv4guisvFSIeqClass::sv4guisvFSIeqClass(const QString& eq)
 
     backflowStab=0.3;
 
-    lsType="NS";//NS, GMRES, CG, BICG
+    //lsType="NS";//NS, GMRES, CG, BICG
+    lsType="GMRES";
     lsMaxItr=10;
     lsTol="1e-4";
     lsNSGMMaxItr=5;
@@ -131,8 +132,8 @@ sv4guisvFSIeqClass::sv4guisvFSIeqClass(const QString& eq)
     lsNSCGMaxItr=500;
     lsNSCGTol="1e-4";
     lsKrylovDim=50;
-    lsAbsoluteTol="1e-12";
-    lsPreconditioner="";
+    lsAbsoluteTol="1e-4";
+    lsPreconditioner="Default";
 
     remesher="None";
     rmMinAngle=10.0;

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/plugin.xml
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/plugin.xml
@@ -6,16 +6,16 @@
           name="SV 2D Segmentation"
           class="sv4guiSeg2DEdit"
           icon="resources/contourgroup.png" />
-    <view id="org.sv.views.segmentation3d"
+    <!--<view id="org.sv.views.segmentation3d"
           name="SV 3D Segmentation"
           class="sv4guiSeg3DEdit"
-          icon="resources/svseg3d.png" />
+          icon="resources/svseg3d.png" />-->
 
   </extension>
 
   <extension point="org.sv.gui.qt.datamanager.contextMenuActions">
       <contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Create Contour Group" icon="" class="sv4guiContourGroupCreateAction" />
-      <contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Create 3D Segmentation" icon="" class="sv4guiSeg3DCreateAction" />
+      <!--<contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Create 3D Segmentation" icon="" class="sv4guiSeg3DCreateAction" />-->
       <contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Import Segmentations" icon="" class="sv4guiSegmentationLoadAction" />
       <contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Import Legacy Segmentations" icon="" class="sv4guiSegmentationLegacyLoadAction" />
       <contextMenuAction nodeDescriptorName="sv4guiSegmentationFolder" label="Export All as Legacy Segmentations" icon="" class="sv4guiSegmentationLegacySaveAction" />

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.svfsi/sv4gui_svFSIView.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.svfsi/sv4gui_svFSIView.cxx
@@ -157,6 +157,7 @@ void sv4guisvFSIView::CreateQtPartControl( QWidget *parent )
     connect(ui->maxItr, SIGNAL(editingFinished()), this, SLOT(SaveAdvanced()));
 
     //linear solver
+    ShowNSWidget();
     connect(ui->comboBoxLSType, SIGNAL(currentTextChanged(const QString &)), this, SLOT(SaveLinearSolver()));
     connect(ui->comboBoxLSType, SIGNAL(currentTextChanged(const QString &)), this, SLOT(ShowNSWidget()));
 

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.svfsi/sv4gui_svFSIView.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.svfsi/sv4gui_svFSIView.ui
@@ -351,7 +351,7 @@
                <enum>QTabWidget::North</enum>
               </property>
               <property name="currentIndex">
-               <number>5</number>
+               <number>4</number>
               </property>
               <widget class="QWidget" name="tab">
                <attribute name="title">
@@ -1956,8 +1956,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>487</width>
-           <height>626</height>
+           <width>318</width>
+           <height>477</height>
           </rect>
          </property>
          <attribute name="label">
@@ -2504,8 +2504,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>487</width>
-           <height>626</height>
+           <width>164</width>
+           <height>123</height>
           </rect>
          </property>
          <attribute name="label">


### PR DESCRIPTION
removed the old 3d segmentation icon. However users will see an error if they double click a 3d segmentation in the datamanager now.