### PR TITLE
BUG: edited hdf5 cmake so that installed simvascular can discover it …

### DIFF
--- a/Code/CMake/Externals/HDF5.cmake
+++ b/Code/CMake/Externals/HDF5.cmake
@@ -57,8 +57,7 @@ if(SV_USE_${proj})
     )
 
   # Set SV_HDF5_DIR to the directory that was found to contain HDF5
-  set(SV_${proj}_DIR ${${proj}_DIR})
+  #set(SV_${proj}_DIR ${${proj}_DIR})
 
 endif()
 #-----------------------------------------------------------------------------
-


### PR DESCRIPTION
Hey,

Been working on the linux install. This line needs to be commented out or else the installed SimVascular can't find HDF5.

Haven't tested on windows or mac.