### PR TITLE
Add external versions needed by plugins.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 Code/SV3
 Code/svSolver
 Code/Licensed/ParasolidSolidModel

--- a/Code/CMake/SimVascularUseExternals.cmake
+++ b/Code/CMake/SimVascularUseExternals.cmake
@@ -119,38 +119,42 @@ endif()
 
 #-----------------------------------------------------------------------------
 # Qt5
-simvascular_add_new_external(Qt5 5.4.2 ON ON qt)
 
-# TCL
-simvascular_add_new_external(TCL 8.6.4 ON ON tcltk)
+if(SV_EXTERNALS_VERSION_NUMBER VERSION_EQUAL "2018.01")
+    simvascular_add_new_external(Qt5 5.4.2 ON ON qt)
+    simvascular_add_new_external(TCL 8.6.4 ON ON tcltk)
+    if(WIN32)
+      simvascular_add_new_external(PYTHON 2.7.13 ON ON python)
+    else()
+      simvascular_add_new_external(PYTHON 2.7.11 ON ON python)
+    endif()
+    simvascular_add_new_external(FREETYPE 2.6.3 ON ON freetype)
+    simvascular_add_new_external(MMG 5.1.0 ON OFF mmg)
+    simvascular_add_new_external(VTK 6.2.0 ON ON vtk)
+    simvascular_add_new_external(GDCM 2.6.1 ON ON gdcm)
+    simvascular_add_new_external(ITK 4.7.1 ON ON itk)
+    simvascular_add_new_external(OpenCASCADE 7.0.0 ON ON opencascade)
+    simvascular_add_new_external(MITK 2016.03 ON ON mitk)
 
-#PYTHON
-if(WIN32)
-  simvascular_add_new_external(PYTHON 2.7.13 ON ON python)
-else()
-  simvascular_add_new_external(PYTHON 2.7.11 ON ON python)
+elseif(SV_EXTERNALS_VERSION_NUMBER VERSION_EQUAL "2018.05")
+    simvascular_add_new_external(Qt5 5.6.3 ON ON qt)
+    simvascular_add_new_external(HDF5 1.10.1 ON ON hdf5)
+    simvascular_add_new_external(TCL 8.6.4 ON ON tcltk)
+    if(WIN32)
+      simvascular_add_new_external(PYTHON 2.7.13 ON ON python)
+    else()
+      simvascular_add_new_external(PYTHON 3.5.5 ON ON python)
+    endif()
+    simvascular_add_new_external(FREETYPE 2.6.3 ON ON freetype)
+    simvascular_add_new_external(MMG 5.3.9 ON OFF mmg)
+    simvascular_add_new_external(GDCM 2.6.3 ON ON gdcm)
+    simvascular_add_new_external(VTK 8.1.1 ON ON vtk)
+    simvascular_add_new_external(ITK 4.13.0 ON ON itk)
+    simvascular_add_new_external(OpenCASCADE 7.3.0 ON ON opencascade)
+    simvascular_add_new_external(MITK 2018.04.0 ON ON mitk)
+
 endif()
 
-#FREETYPE
-simvascular_add_new_external(FREETYPE 2.6.3 ON ON freetype)
-
-# MMG
-simvascular_add_new_external(MMG 5.1.0 ON OFF mmg)
-
-# VTK
-simvascular_add_new_external(VTK 6.2.0 ON ON vtk)
-
-# GDCM
-simvascular_add_new_external(GDCM 2.6.1 ON ON gdcm)
-
-# ITK
-simvascular_add_new_external(ITK 4.7.1 ON ON itk)
-
-# OpenCASCADE
-simvascular_add_new_external(OpenCASCADE 7.0.0 ON ON opencascade)
-
-# MITK
-simvascular_add_new_external(MITK 2016.03 ON ON mitk)
 #-----------------------------------------------------------------------------
 
 #-----------------------------------------------------------------------------

--- a/Externals/CMake/SvExtVersions.cmake
+++ b/Externals/CMake/SvExtVersions.cmake
@@ -27,7 +27,8 @@
 
 #-----------------------------------------------------------------------------
 # URLs for external downloads and git repositories
-set(SV_EXTERNALS_VERSION_NUMBER "2018.01" CACHE STRING "SimVascular Externals version")
+set(SV_EXTERNALS_VERSION_NUMBER "2018.05" CACHE STRING "SimVascular Externals version")
+#set(SV_EXTERNALS_VERSION_NUMBER "2018.01" CACHE STRING "SimVascular Externals version")
 set_property(CACHE SV_EXTERNALS_VERSION_NUMBER PROPERTY STRINGS "2017.01" "2018.01" "2018.03" "2018.05")
 #-----------------------------------------------------------------------------
 


### PR DESCRIPTION
Custom plugins use CMake files a bit differently than the usual sv when building. External versions were hard coded in SimVascularUseExternals.cmake. 

There are two places where external version numbers (e.g. mitk version . number) are specified in the CMake file so we should really restructured them someone to set them in a single place.

Plugins will need to set the externals version number in their CMakeLists.txt file 

          set(SV_EXTERNALS_VERSION_NUMBER "2018.05" CACHE STRING "SimVascular Externals Release Version")