### PR TITLE
Fix incorrect array addressing.

### DIFF
--- a/Code/Source/sv/Mesh/VMTKUtils/sv_vmtk_utils.cxx
+++ b/Code/Source/sv/Mesh/VMTKUtils/sv_vmtk_utils.cxx
@@ -124,13 +124,14 @@ int sys_geom_centerlines( cvPolyData *polydata,int *sources,int nsources,
 
   fprintf(stderr,"NumSources %d\n",nsources);
   fprintf(stderr,"NumTargets %d\n",ntargets);
+
   for (pointId = 0;pointId<nsources;pointId++)
   {
-    capInletIds->InsertNextId(*sources+pointId);
+    capInletIds->InsertNextId(sources[pointId]);
   }
   for (pointId = 0;pointId<ntargets;pointId++)
   {
-    capOutletIds->InsertNextId(*targets+pointId);
+    capOutletIds->InsertNextId(targets[pointId]);
   }
 
   vtkNew(vtkvmtkPolyDataCenterlines,centerLiner);


### PR DESCRIPTION
Centerlines were not being computed correctly. The problem was caused by incorrect array addressing while copying source and target IDs. 