### PR TITLE
Add CMake code to copy SV Python/site-packages to the MacOS installer…

### DIFF
--- a/Distribution/CMakeLists.txt
+++ b/Distribution/CMakeLists.txt
@@ -192,6 +192,9 @@ if(APPLE)
 		if(SV_DEVELOPER_OUTPUT)
 			message(STATUS "CPACK_PACKAGE_FILE_NAME: ${CPACK_PACKAGE_FILE_NAME}.dmg")
 		endif()
+
+                INSTALL(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/../Python/site-packages" 
+                        DESTINATION "Python${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}")
 	endif()
 endif(APPLE)
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
…. Issue #471.

You can now **import sv** from the SV Python console.