### PR TITLE
changing ml tab orders and only loading networks on button press

### DIFF
--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
@@ -1875,24 +1875,21 @@ void sv4guiSeg2DEdit::setupMLui(){
 
   updatePaths();
 
-  ui->segToolbox->setCurrentIndex(0);
-
 }
 
 void sv4guiSeg2DEdit::segTabSelected(){
   std::cout << "select seg tab\n";
   switch(ui->segToolbox->currentIndex()){
-    case 0:
-          initialize();
+    case 1:
     break;
 
-    case 1:
+    case 0:
       std::cout << "single path selected\n";
       if(!m_ContourGroup)
       {
           ui->resliceSlider->turnOnReslice(false);
           ClearAll();
-          ui->segToolbox->setCurrentIndex(0);
+          ui->segToolbox->setCurrentIndex(1);
           QMessageBox::warning(NULL,"No segmentation selected","Create, or Select a segmentation before choosing single path segmentation!");
       }
     break;
@@ -2013,6 +2010,7 @@ void sv4guiSeg2DEdit::updatePaths(){
 
 void sv4guiSeg2DEdit::segmentPaths(){
   //paths
+  initialize();
   auto path_folder_node = GetDataStorage()->GetNamedNode("Paths");
   auto paths_list       = GetDataStorage()->GetDerivations(path_folder_node);
 

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
@@ -15,261 +15,222 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <widget class="QToolBox" name="segToolbox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>400</width>
-        <height>660</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Single path segmentation</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QWidget" name="widget_8" native="true">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+    <widget class="QWidget" name="widget_9" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_7">
+      <item>
+       <widget class="QToolBox" name="segToolbox">
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QWidget" name="page_2">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>393</width>
+           <height>654</height>
+          </rect>
          </property>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <attribute name="label">
+          <string>Single path segmentation</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout">
           <item>
-           <widget class="QWidget" name="widget_4" native="true">
-            <layout class="QGridLayout" name="gridLayout_2">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <property name="spacing">
-              <number>5</number>
-             </property>
-             <item row="0" column="2">
-              <widget class="QCheckBox" name="checkBoxShowPath">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Show Path</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_6">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Path:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelPathName">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line_2">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+           <widget class="QWidget" name="widget_8" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_5" native="true">
-            <layout class="QGridLayout" name="gridLayout">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>5</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <property name="spacing">
-              <number>5</number>
-             </property>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_16">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Contour Group:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QLabel" name="labelGroupName">
-               <property name="text">
-                <string/>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2">
-              <widget class="QPushButton" name="btnNewGroup">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>New Group</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_7" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>3</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>3</number>
-             </property>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
              <item>
-              <widget class="QCheckBox" name="checkBoxLoftingPreview">
-               <property name="toolTip">
-                <string>Switch on to create a lofted surface from the group</string>
-               </property>
-               <property name="text">
-                <string>Lofting Preview</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnLoftingOptions">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="text">
-                <string>Lofting Parameters...</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="Line" name="line">
-            <property name="frameShadow">
-             <enum>QFrame::Plain</enum>
-            </property>
-            <property name="lineWidth">
-             <number>2</number>
-            </property>
-            <property name="midLineWidth">
-             <number>1</number>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_6" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_8">
-             <property name="spacing">
-              <number>0</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>2</number>
-             </property>
-             <item>
-              <widget class="sv4guiResliceSlider" name="resliceSlider" native="true"/>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="widget_2" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <property name="spacing">
-              <number>5</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>3</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>5</number>
-             </property>
-             <item>
-              <widget class="QWidget" name="widget" native="true">
-               <layout class="QVBoxLayout" name="verticalLayout_3">
+              <widget class="QWidget" name="widget_4" native="true">
+               <layout class="QGridLayout" name="gridLayout_2">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
                 <property name="spacing">
-                 <number>2</number>
+                 <number>5</number>
+                </property>
+                <item row="0" column="2">
+                 <widget class="QCheckBox" name="checkBoxShowPath">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Show Path</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_6">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Path:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLabel" name="labelPathName">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_5" native="true">
+               <layout class="QGridLayout" name="gridLayout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>5</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <property name="spacing">
+                 <number>5</number>
+                </property>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_16">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Contour Group:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="1">
+                 <widget class="QLabel" name="labelGroupName">
+                  <property name="text">
+                   <string/>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="2">
+                 <widget class="QPushButton" name="btnNewGroup">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>New Group</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_7" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_9">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>3</number>
+                </property>
+                <item>
+                 <widget class="QCheckBox" name="checkBoxLoftingPreview">
+                  <property name="toolTip">
+                   <string>Switch on to create a lofted surface from the group</string>
+                  </property>
+                  <property name="text">
+                   <string>Lofting Preview</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnLoftingOptions">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>Lofting Parameters...</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="Line" name="line">
+               <property name="frameShadow">
+                <enum>QFrame::Plain</enum>
+               </property>
+               <property name="lineWidth">
+                <number>2</number>
+               </property>
+               <property name="midLineWidth">
+                <number>1</number>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_6" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout_8">
+                <property name="spacing">
+                 <number>0</number>
                 </property>
                 <property name="leftMargin">
                  <number>0</number>
@@ -281,13 +242,37 @@
                  <number>0</number>
                 </property>
                 <property name="bottomMargin">
-                 <number>0</number>
+                 <number>2</number>
                 </property>
                 <item>
-                 <widget class="QWidget" name="paramWidget" native="true">
-                  <layout class="QVBoxLayout" name="paramLayout">
+                 <widget class="sv4guiResliceSlider" name="resliceSlider" native="true"/>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="widget_2" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <property name="spacing">
+                 <number>5</number>
+                </property>
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>3</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>5</number>
+                </property>
+                <item>
+                 <widget class="QWidget" name="widget" native="true">
+                  <layout class="QVBoxLayout" name="verticalLayout_3">
                    <property name="spacing">
-                    <number>30</number>
+                    <number>2</number>
                    </property>
                    <property name="leftMargin">
                     <number>0</number>
@@ -302,24 +287,126 @@
                     <number>0</number>
                    </property>
                    <item>
-                    <widget class="QFrame" name="lsParamWidgetContainer">
-                     <property name="frameShape">
-                      <enum>QFrame::StyledPanel</enum>
+                    <widget class="QWidget" name="paramWidget" native="true">
+                     <layout class="QVBoxLayout" name="paramLayout">
+                      <property name="spacing">
+                       <number>30</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QFrame" name="lsParamWidgetContainer">
+                        <property name="frameShape">
+                         <enum>QFrame::StyledPanel</enum>
+                        </property>
+                        <property name="frameShadow">
+                         <enum>QFrame::Raised</enum>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QFrame" name="thresholdWidgetContainer">
+                        <property name="frameShape">
+                         <enum>QFrame::StyledPanel</enum>
+                        </property>
+                        <property name="frameShadow">
+                         <enum>QFrame::Raised</enum>
+                        </property>
+                        <layout class="QHBoxLayout" name="horizontalLayout_7">
+                         <property name="spacing">
+                          <number>0</number>
+                         </property>
+                         <property name="leftMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="topMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="rightMargin">
+                          <number>0</number>
+                         </property>
+                         <property name="bottomMargin">
+                          <number>0</number>
+                         </property>
+                         <item>
+                          <widget class="QGroupBox" name="thresholdParamWidget">
+                           <property name="title">
+                            <string>Threshold</string>
+                           </property>
+                           <property name="flat">
+                            <bool>false</bool>
+                           </property>
+                           <layout class="QHBoxLayout" name="horizontalLayout_2">
+                            <property name="spacing">
+                             <number>0</number>
+                            </property>
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>2</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item>
+                             <widget class="QCheckBox" name="checkBoxPresetThreshold">
+                              <property name="toolTip">
+                               <string>switch on to use a specified value to create a contour.</string>
+                              </property>
+                              <property name="text">
+                               <string> Preset</string>
+                              </property>
+                             </widget>
+                            </item>
+                            <item>
+                             <widget class="ctkSliderWidget" name="sliderThreshold" native="true">
+                              <property name="enabled">
+                               <bool>true</bool>
+                              </property>
+                              <property name="decimals" stdset="0">
+                               <number>1</number>
+                              </property>
+                              <property name="tickInterval" stdset="0">
+                               <double>0.000000000000000</double>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                        </layout>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line_4">
+                     <property name="lineWidth">
+                      <number>0</number>
                      </property>
-                     <property name="frameShadow">
-                      <enum>QFrame::Raised</enum>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
                      </property>
                     </widget>
                    </item>
                    <item>
-                    <widget class="QFrame" name="thresholdWidgetContainer">
-                     <property name="frameShape">
-                      <enum>QFrame::StyledPanel</enum>
-                     </property>
-                     <property name="frameShadow">
-                      <enum>QFrame::Raised</enum>
-                     </property>
-                     <layout class="QHBoxLayout" name="horizontalLayout_7">
+                    <widget class="QWidget" name="smoothWidget" native="true">
+                     <layout class="QHBoxLayout" name="horizontalLayout_3">
                       <property name="spacing">
                        <number>0</number>
                       </property>
@@ -336,76 +423,137 @@
                        <number>0</number>
                       </property>
                       <item>
-                       <widget class="QGroupBox" name="thresholdParamWidget">
-                        <property name="title">
-                         <string>Threshold</string>
+                       <widget class="QCheckBox" name="checkBoxSmooth">
+                        <property name="toolTip">
+                         <string>Switch on to smooth a contour after created by levelset or threshold</string>
                         </property>
-                        <property name="flat">
-                         <bool>false</bool>
+                        <property name="text">
+                         <string>Smooth   Fourier Number:</string>
                         </property>
-                        <layout class="QHBoxLayout" name="horizontalLayout_2">
-                         <property name="spacing">
-                          <number>0</number>
-                         </property>
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>2</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item>
-                          <widget class="QCheckBox" name="checkBoxPresetThreshold">
-                           <property name="toolTip">
-                            <string>switch on to use a specified value to create a contour.</string>
-                           </property>
-                           <property name="text">
-                            <string> Preset</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="ctkSliderWidget" name="sliderThreshold" native="true">
-                           <property name="enabled">
-                            <bool>true</bool>
-                           </property>
-                           <property name="decimals" stdset="0">
-                            <number>1</number>
-                           </property>
-                           <property name="tickInterval" stdset="0">
-                            <double>0.000000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QSpinBox" name="spinBoxSmoothNumber">
+                        <property name="minimum">
+                         <number>5</number>
+                        </property>
+                        <property name="maximum">
+                         <number>20</number>
+                        </property>
+                        <property name="value">
+                         <number>12</number>
+                        </property>
                        </widget>
                       </item>
                      </layout>
                     </widget>
                    </item>
+                   <item>
+                    <widget class="QWidget" name="splineWidget" native="true">
+                     <layout class="QHBoxLayout" name="horizontalLayout_4">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QCheckBox" name="checkBoxSpline">
+                        <property name="toolTip">
+                         <string>Switch on to  converte a contour to a SplinePolygon smooth  after created by levelset or threshold</string>
+                        </property>
+                        <property name="text">
+                         <string>Convert to Spline   Ctrl No.:</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QSpinBox" name="spinBoxControlNumber">
+                        <property name="minimum">
+                         <number>5</number>
+                        </property>
+                        <property name="maximum">
+                         <number>40</number>
+                        </property>
+                        <property name="value">
+                         <number>12</number>
+                        </property>
+                       </widget>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QWidget" name="batchWidget" native="true">
+                     <layout class="QHBoxLayout" name="horizontalLayout_5">
+                      <property name="spacing">
+                       <number>0</number>
+                      </property>
+                      <property name="leftMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="topMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="rightMargin">
+                       <number>0</number>
+                      </property>
+                      <property name="bottomMargin">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <widget class="QCheckBox" name="checkBoxBatch">
+                        <property name="toolTip">
+                         <string>Switch on to enable batch segmentation by levelset or threshold</string>
+                        </property>
+                        <property name="text">
+                         <string>Batch Mode  List:</string>
+                        </property>
+                       </widget>
+                      </item>
+                      <item>
+                       <widget class="QLineEdit" name="lineEditBatchList"/>
+                      </item>
+                     </layout>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="Line" name="line_5">
+                     <property name="lineWidth">
+                      <number>0</number>
+                     </property>
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label">
+                     <property name="text">
+                      <string>Contour List:</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QListWidget" name="listWidget"/>
+                   </item>
                   </layout>
                  </widget>
                 </item>
                 <item>
-                 <widget class="Line" name="line_4">
-                  <property name="lineWidth">
-                   <number>0</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="smoothWidget" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_3">
+                 <widget class="QWidget" name="widget_3" native="true">
+                  <layout class="QVBoxLayout" name="verticalLayout_2">
                    <property name="spacing">
-                    <number>0</number>
+                    <number>6</number>
                    </property>
                    <property name="leftMargin">
                     <number>0</number>
@@ -420,169 +568,24 @@
                     <number>0</number>
                    </property>
                    <item>
-                    <widget class="QCheckBox" name="checkBoxSmooth">
+                    <widget class="QPushButton" name="btnLevelSet">
                      <property name="toolTip">
-                      <string>Switch on to smooth a contour after created by levelset or threshold</string>
-                     </property>
-                     <property name="text">
-                      <string>Smooth   Fourier Number:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="spinBoxSmoothNumber">
-                     <property name="minimum">
-                      <number>5</number>
-                     </property>
-                     <property name="maximum">
-                      <number>20</number>
-                     </property>
-                     <property name="value">
-                      <number>12</number>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="splineWidget" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_4">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="checkBoxSpline">
-                     <property name="toolTip">
-                      <string>Switch on to  converte a contour to a SplinePolygon smooth  after created by levelset or threshold</string>
-                     </property>
-                     <property name="text">
-                      <string>Convert to Spline   Ctrl No.:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QSpinBox" name="spinBoxControlNumber">
-                     <property name="minimum">
-                      <number>5</number>
-                     </property>
-                     <property name="maximum">
-                      <number>40</number>
-                     </property>
-                     <property name="value">
-                      <number>12</number>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QWidget" name="batchWidget" native="true">
-                  <layout class="QHBoxLayout" name="horizontalLayout_5">
-                   <property name="spacing">
-                    <number>0</number>
-                   </property>
-                   <property name="leftMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="topMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="rightMargin">
-                    <number>0</number>
-                   </property>
-                   <property name="bottomMargin">
-                    <number>0</number>
-                   </property>
-                   <item>
-                    <widget class="QCheckBox" name="checkBoxBatch">
-                     <property name="toolTip">
-                      <string>Switch on to enable batch segmentation by levelset or threshold</string>
-                     </property>
-                     <property name="text">
-                      <string>Batch Mode  List:</string>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QLineEdit" name="lineEditBatchList"/>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="Line" name="line_5">
-                  <property name="lineWidth">
-                   <number>0</number>
-                  </property>
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label">
-                  <property name="text">
-                   <string>Contour List:</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QListWidget" name="listWidget"/>
-                </item>
-               </layout>
-              </widget>
-             </item>
-             <item>
-              <widget class="QWidget" name="widget_3" native="true">
-               <layout class="QVBoxLayout" name="verticalLayout_2">
-                <property name="spacing">
-                 <number>6</number>
-                </property>
-                <property name="leftMargin">
-                 <number>0</number>
-                </property>
-                <property name="topMargin">
-                 <number>0</number>
-                </property>
-                <property name="rightMargin">
-                 <number>0</number>
-                </property>
-                <property name="bottomMargin">
-                 <number>0</number>
-                </property>
-                <item>
-                 <widget class="QPushButton" name="btnLevelSet">
-                  <property name="toolTip">
-                   <string>Click to show the levelset parameter panel.
+                      <string>Click to show the levelset parameter panel.
 Click again to create a contour by levelset.
 (Shortcut: Ctrl+L)</string>
-                  </property>
-                  <property name="text">
-                   <string>LevelSet</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnThreshold">
-                  <property name="toolTip">
-                   <string>Click to show the threshold parameter panel.
+                     </property>
+                     <property name="text">
+                      <string>LevelSet</string>
+                     </property>
+                     <property name="checkable">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnThreshold">
+                     <property name="toolTip">
+                      <string>Click to show the threshold parameter panel.
 
 Click again and the button becomes blue (active for interaction). 
 Then, you need to move the cursor to a 2D view window, click and hold the left moust button, move up/down, then release to finish a contour.
@@ -590,200 +593,203 @@ Then, you need to move the cursor to a 2D view window, click and hold the left m
 If &quot;Preset&quot; on,  a contour is created with a specified threshold value, you click the button.
 
 (Shortcut: Ctrl+T)</string>
-                  </property>
-                  <property name="text">
-                   <string>Threshold</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnML">
-                  <property name="text">
-                   <string>NN</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_2">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnCircle">
-                  <property name="contextMenuPolicy">
-                   <enum>Qt::CustomContextMenu</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Interactive method:
+                     </property>
+                     <property name="text">
+                      <string>Threshold</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnML">
+                     <property name="text">
+                      <string>NN</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_2">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnCircle">
+                     <property name="contextMenuPolicy">
+                      <enum>Qt::CustomContextMenu</enum>
+                     </property>
+                     <property name="toolTip">
+                      <string>Interactive method:
 Click and the button becomes blue (active for interaction).
 Then, you need to move the cursor to a 2D view window, click and move to create a contour.
 
 Manual method:
 Right click and manually provide center coordiantes and radius.</string>
-                  </property>
-                  <property name="text">
-                   <string>Circle</string>
-                  </property>
-                  <property name="checkable">
-                   <bool>false</bool>
-                  </property>
-                  <property name="checked">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnEllipse">
-                  <property name="contextMenuPolicy">
-                   <enum>Qt::CustomContextMenu</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Interactive method:
+                     </property>
+                     <property name="text">
+                      <string>Circle</string>
+                     </property>
+                     <property name="checkable">
+                      <bool>false</bool>
+                     </property>
+                     <property name="checked">
+                      <bool>false</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnEllipse">
+                     <property name="contextMenuPolicy">
+                      <enum>Qt::CustomContextMenu</enum>
+                     </property>
+                     <property name="toolTip">
+                      <string>Interactive method:
 Click and the button becomes blue (active for interaction).
 Then, you need to move the cursor to a 2D view window, click and move to create a contour.
 
 Manual method:
 Right click and manually provide center coordiantes and semi-axis lengths.</string>
-                  </property>
-                  <property name="text">
-                   <string>Ellipse</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnSplinePoly">
-                  <property name="contextMenuPolicy">
-                   <enum>Qt::CustomContextMenu</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Interactive method:
+                     </property>
+                     <property name="text">
+                      <string>Ellipse</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnSplinePoly">
+                     <property name="contextMenuPolicy">
+                      <enum>Qt::CustomContextMenu</enum>
+                     </property>
+                     <property name="toolTip">
+                      <string>Interactive method:
 Click and the button becomes blue (active for interaction). 
 Then, you need to move the cursor to a 2D view window, click and move to add control points, double click or press &quot;F&quot; to finish.
 
 Manual method:
 Right click and manually provide coordiantes for control points.</string>
-                  </property>
-                  <property name="text">
-                   <string>SplinePoly</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnPolygon">
-                  <property name="contextMenuPolicy">
-                   <enum>Qt::CustomContextMenu</enum>
-                  </property>
-                  <property name="toolTip">
-                   <string>Interactive method:
+                     </property>
+                     <property name="text">
+                      <string>SplinePoly</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnPolygon">
+                     <property name="contextMenuPolicy">
+                      <enum>Qt::CustomContextMenu</enum>
+                     </property>
+                     <property name="toolTip">
+                      <string>Interactive method:
 Click and the button becomes blue (active for interaction). 
 Then, you need to move the cursor to a 2D view window, click and move to add control points, double click or press &quot;F&quot; to finish.
 
 Manual method:
 Right click and manually provide coordiantes for control points.</string>
-                  </property>
-                  <property name="text">
-                   <string>Polygon</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_3">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnSmooth">
-                  <property name="toolTip">
-                   <string>Smooth the selected contour using the specified Fourier number.</string>
-                  </property>
-                  <property name="text">
-                   <string>Smooth</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_4">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnCopy">
-                  <property name="toolTip">
-                   <string>Copy the selected contour.
+                     </property>
+                     <property name="text">
+                      <string>Polygon</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_3">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnSmooth">
+                     <property name="toolTip">
+                      <string>Smooth the selected contour using the specified Fourier number.</string>
+                     </property>
+                     <property name="text">
+                      <string>Smooth</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_4">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnCopy">
+                     <property name="toolTip">
+                      <string>Copy the selected contour.
 (Shortcut: Ctrl+C)</string>
-                  </property>
-                  <property name="text">
-                   <string>Copy</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnPaste">
-                  <property name="toolTip">
-                   <string>Paste to the current location along the path.
+                     </property>
+                     <property name="text">
+                      <string>Copy</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnPaste">
+                     <property name="toolTip">
+                      <string>Paste to the current location along the path.
 (Shortcut: Ctrl+V)</string>
-                  </property>
-                  <property name="text">
-                   <string>Paste</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLabel" name="label_5">
-                  <property name="text">
-                   <string/>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="btnDelete">
-                  <property name="toolTip">
-                   <string>Delete the selected contour.
+                     </property>
+                     <property name="text">
+                      <string>Paste</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QLabel" name="label_5">
+                     <property name="text">
+                      <string/>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="btnDelete">
+                     <property name="toolTip">
+                      <string>Delete the selected contour.
 (Shortcut: Ctrl+D)
 
 You can also move the cursor to a 2D view and click.
 Then, press key Delete to remove the shown contour.</string>
-                  </property>
-                  <property name="text">
-                   <string>Delete</string>
-                  </property>
+                     </property>
+                     <property name="text">
+                      <string>Delete</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <spacer name="verticalSpacer">
+                     <property name="orientation">
+                      <enum>Qt::Vertical</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>20</width>
+                       <height>40</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                  </layout>
+                  <zorder>btnCircle</zorder>
+                  <zorder>btnLevelSet</zorder>
+                  <zorder>btnEllipse</zorder>
+                  <zorder>btnPolygon</zorder>
+                  <zorder>btnSplinePoly</zorder>
+                  <zorder>btnDelete</zorder>
+                  <zorder>btnThreshold</zorder>
+                  <zorder>btnSmooth</zorder>
+                  <zorder>btnCopy</zorder>
+                  <zorder>btnPaste</zorder>
+                  <zorder>label_2</zorder>
+                  <zorder>label_3</zorder>
+                  <zorder>label_4</zorder>
+                  <zorder>label_5</zorder>
+                  <zorder>btnML</zorder>
                  </widget>
                 </item>
-                <item>
-                 <spacer name="verticalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>40</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
                </layout>
-               <zorder>btnCircle</zorder>
-               <zorder>btnLevelSet</zorder>
-               <zorder>btnEllipse</zorder>
-               <zorder>btnPolygon</zorder>
-               <zorder>btnSplinePoly</zorder>
-               <zorder>btnDelete</zorder>
-               <zorder>btnThreshold</zorder>
-               <zorder>btnSmooth</zorder>
-               <zorder>btnCopy</zorder>
-               <zorder>btnPaste</zorder>
-               <zorder>label_2</zorder>
-               <zorder>label_3</zorder>
-               <zorder>label_4</zorder>
-               <zorder>label_5</zorder>
-               <zorder>btnML</zorder>
               </widget>
              </item>
             </layout>
@@ -791,123 +797,101 @@ Then, press key Delete to remove the shown contour.</string>
           </item>
          </layout>
         </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>400</width>
-        <height>660</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Multi path segmentation</string>
-      </attribute>
-      <widget class="QLineEdit" name="fourierEdit">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>320</y>
-         <width>113</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>7</string>
-       </property>
-      </widget>
-      <widget class="QListWidget" name="pathList">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>80</y>
-         <width>256</width>
-         <height>192</height>
-        </rect>
-       </property>
-      </widget>
-      <widget class="QLabel" name="intervalLabel">
-       <property name="geometry">
-        <rect>
-         <x>50</x>
-         <y>290</y>
-         <width>67</width>
-         <height>17</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Interval</string>
-       </property>
-      </widget>
-      <widget class="QPushButton" name="multiSegButton">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>410</y>
-         <width>131</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Segment Paths</string>
-       </property>
-      </widget>
-      <widget class="QCheckBox" name="selectAllPathsCheckBox">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>60</y>
-         <width>131</width>
-         <height>22</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>select all paths</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_7">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>40</y>
-         <width>67</width>
-         <height>17</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Paths</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="intervalEdit">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>290</y>
-         <width>113</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>10</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="fourierLabel">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>320</y>
-         <width>101</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Fourier Modes</string>
-       </property>
-      </widget>
-     </widget>
+        <widget class="QWidget" name="page">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>0</y>
+           <width>382</width>
+           <height>642</height>
+          </rect>
+         </property>
+         <attribute name="label">
+          <string>Multi path segmentation</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Paths</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="selectAllPathsCheckBox">
+            <property name="text">
+             <string>select all paths</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QListWidget" name="pathList"/>
+          </item>
+          <item>
+           <widget class="QWidget" name="widget_10" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_6">
+             <item>
+              <widget class="QLabel" name="intervalLabel">
+               <property name="text">
+                <string>Interval</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="intervalEdit">
+               <property name="text">
+                <string>10</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="widget_11" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout_10">
+             <item>
+              <widget class="QLabel" name="fourierLabel">
+               <property name="text">
+                <string>Fourier Modes</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLineEdit" name="fourierEdit">
+               <property name="text">
+                <string>7</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="multiSegButton">
+            <property name="text">
+             <string>Segment Paths</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
@@ -17,122 +17,8 @@
    <item>
     <widget class="QToolBox" name="segToolbox">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>400</width>
-        <height>660</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Multi path segmentation</string>
-      </attribute>
-      <widget class="QLineEdit" name="fourierEdit">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>320</y>
-         <width>113</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>7</string>
-       </property>
-      </widget>
-      <widget class="QListWidget" name="pathList">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>80</y>
-         <width>256</width>
-         <height>192</height>
-        </rect>
-       </property>
-      </widget>
-      <widget class="QLabel" name="intervalLabel">
-       <property name="geometry">
-        <rect>
-         <x>50</x>
-         <y>290</y>
-         <width>67</width>
-         <height>17</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Interval</string>
-       </property>
-      </widget>
-      <widget class="QPushButton" name="multiSegButton">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>410</y>
-         <width>131</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Segment Paths</string>
-       </property>
-      </widget>
-      <widget class="QCheckBox" name="selectAllPathsCheckBox">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>60</y>
-         <width>131</width>
-         <height>22</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>select all paths</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_7">
-       <property name="geometry">
-        <rect>
-         <x>70</x>
-         <y>40</y>
-         <width>67</width>
-         <height>17</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Paths</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="intervalEdit">
-       <property name="geometry">
-        <rect>
-         <x>120</x>
-         <y>290</y>
-         <width>113</width>
-         <height>27</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>10</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="fourierLabel">
-       <property name="geometry">
-        <rect>
-         <x>20</x>
-         <y>320</y>
-         <width>101</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Fourier Modes</string>
-       </property>
-      </widget>
-     </widget>
      <widget class="QWidget" name="page_2">
       <property name="geometry">
        <rect>
@@ -907,6 +793,120 @@ Then, press key Delete to remove the shown contour.</string>
         </widget>
        </item>
       </layout>
+     </widget>
+     <widget class="QWidget" name="page">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>400</width>
+        <height>660</height>
+       </rect>
+      </property>
+      <attribute name="label">
+       <string>Multi path segmentation</string>
+      </attribute>
+      <widget class="QLineEdit" name="fourierEdit">
+       <property name="geometry">
+        <rect>
+         <x>120</x>
+         <y>320</y>
+         <width>113</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>7</string>
+       </property>
+      </widget>
+      <widget class="QListWidget" name="pathList">
+       <property name="geometry">
+        <rect>
+         <x>70</x>
+         <y>80</y>
+         <width>256</width>
+         <height>192</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QLabel" name="intervalLabel">
+       <property name="geometry">
+        <rect>
+         <x>50</x>
+         <y>290</y>
+         <width>67</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Interval</string>
+       </property>
+      </widget>
+      <widget class="QPushButton" name="multiSegButton">
+       <property name="geometry">
+        <rect>
+         <x>130</x>
+         <y>410</y>
+         <width>131</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Segment Paths</string>
+       </property>
+      </widget>
+      <widget class="QCheckBox" name="selectAllPathsCheckBox">
+       <property name="geometry">
+        <rect>
+         <x>70</x>
+         <y>60</y>
+         <width>131</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>select all paths</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="label_7">
+       <property name="geometry">
+        <rect>
+         <x>70</x>
+         <y>40</y>
+         <width>67</width>
+         <height>17</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Paths</string>
+       </property>
+      </widget>
+      <widget class="QLineEdit" name="intervalEdit">
+       <property name="geometry">
+        <rect>
+         <x>120</x>
+         <y>290</y>
+         <width>113</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>10</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="fourierLabel">
+       <property name="geometry">
+        <rect>
+         <x>20</x>
+         <y>320</y>
+         <width>101</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="text">
+        <string>Fourier Modes</string>
+       </property>
+      </widget>
      </widget>
     </widget>
    </item>


### PR DESCRIPTION
Chagnes we discussed in sv call. Tab orders are switched and networks are only loaded when the segmentation button is clicked.