### PR TITLE
Fix for not calculating contour center when reading contour groups.

### DIFF
--- a/Code/Source/sv3/Segmentation/sv3_Contour.cxx
+++ b/Code/Source/sv3/Segmentation/sv3_Contour.cxx
@@ -71,7 +71,8 @@ Contour::Contour()
       //m_Selected(false),
       m_MinControlPointNumber(2),
       m_MaxControlPointNumber(2),
-      m_TagIndex(0)
+      m_TagIndex(0),
+      m_CenterPoint{0.0,0.0,0.0}
  {
     for (int i=0;i<5;i++)
     {

--- a/Code/Source/sv4gui/Modules/Segmentation/sv4gui_ContourGroupIO.cxx
+++ b/Code/Source/sv4gui/Modules/Segmentation/sv4gui_ContourGroupIO.cxx
@@ -265,6 +265,7 @@ std::vector<mitk::BaseData::Pointer> sv4guiContourGroupIO::ReadFile(std::string 
                     contourPoints.push_back(sv4guiXmlIOUtil::GetPoint(pointElement));
                 }
                 contour->SetContourPoints(contourPoints,false);
+                contour->ContourPointsChanged(); // Calculate contour center.
             }
 
             group->InsertContour(-1,contour,timestep);


### PR DESCRIPTION
The contour center is used when calculating contour area but the contour center was not being calculated when contour groups are read in. 