### PR TITLE
Lofting parameters button crashes sv 521

### DIFF
--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
@@ -218,7 +218,18 @@ void sv4guiSeg2DEdit::CreateQtPartControl( QWidget *parent )
 
     //ml additions
     setupMLui();
-    m_Parent->setEnabled(true);
+
+    // If m_ContourGroup is null then the panel is not associated with any 
+    // contour group. This happens when tool panels from previous sessions
+    // are created when SV starts.
+    //
+/*
+    if (m_ContourGroup == nullptr) { 
+        //m_Parent->setEnabled(false);
+    } else {
+        m_Parent->setEnabled(true);
+    }
+*/
 }
 
 void sv4guiSeg2DEdit::Visible()
@@ -1291,8 +1302,7 @@ void sv4guiSeg2DEdit::LoftContourGroup()
 
 void sv4guiSeg2DEdit::ShowLoftWidget()
 {
-    svLoftingParam *param=m_ContourGroup->GetLoftingParam();
-
+    svLoftingParam *param = m_ContourGroup->GetLoftingParam();
     m_LoftWidget->UpdateGUI(param);
     m_LoftWidget->show();
 }

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
@@ -223,13 +223,11 @@ void sv4guiSeg2DEdit::CreateQtPartControl( QWidget *parent )
     // contour group. This happens when tool panels from previous sessions
     // are created when SV starts.
     //
-/*
     if (m_ContourGroup == nullptr) { 
-        //m_Parent->setEnabled(false);
+        ui->SinglePathTab->setEnabled(false);
     } else {
-        m_Parent->setEnabled(true);
+        ui->SinglePathTab->setEnabled(true);
     }
-*/
 }
 
 void sv4guiSeg2DEdit::Visible()
@@ -277,7 +275,7 @@ void sv4guiSeg2DEdit::OnSelectionChanged(std::vector<mitk::DataNode*> nodes )
     {
         ui->resliceSlider->turnOnReslice(false);
         ClearAll();
-        //m_Parent->setEnabled(false);
+        ui->SinglePathTab->setEnabled(false);
         return;
     }
 
@@ -298,11 +296,12 @@ void sv4guiSeg2DEdit::OnSelectionChanged(std::vector<mitk::DataNode*> nodes )
         std::cout << "no contour group selected\n";
         ui->resliceSlider->turnOnReslice(false);
         ClearAll();
-        //m_Parent->setEnabled(false);
+        ui->SinglePathTab->setEnabled(false);
         return;
     }
 
     m_Parent->setEnabled(true);
+    ui->SinglePathTab->setEnabled(true);
     ////remove_toolbox     ui->segToolbox->setCurrentIndex(1);
 //    std::string groupPathName=m_ContourGroup->GetPathName();
     int  groupPathID=m_ContourGroup->GetPathID();

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.ui
@@ -19,7 +19,7 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="tab">
+     <widget class="QWidget" name="SinglePathTab">
       <attribute name="title">
        <string>Single-Path</string>
       </attribute>
@@ -786,7 +786,7 @@ Then, press key Delete to remove the shown contour.</string>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="tab_2">
+     <widget class="QWidget" name="MultiVesselTab">
       <attribute name="title">
        <string>Multi-vessel Path</string>
       </attribute>


### PR DESCRIPTION
This is a problem when a 2D Segmentation plugin is opened when a contour group is not defined, for example when SV opens and shows the last active plugin.