### PR TITLE
fixing issue where ml seg would crash if neural networks werent present

### DIFF
--- a/Code/Source/sv4gui/Modules/MachineLearning/sv4gui_MachineLearningUtils.cxx
+++ b/Code/Source/sv4gui/Modules/MachineLearning/sv4gui_MachineLearningUtils.cxx
@@ -88,6 +88,10 @@ sv4gui_MachineLearningUtils::~sv4gui_MachineLearningUtils(){
   //Py_Finalize();
 }
 
+bool sv4gui_MachineLearningUtils::ok(){
+  return !(py_wrapper_inst == NULL);
+}
+
 std::string sv4gui_MachineLearningUtils::setImage(std::string image_path){
   PyObject* py_res = PyObject_CallMethod(py_wrapper_inst, "set_image",
                         "s", image_path.c_str());

--- a/Code/Source/sv4gui/Modules/MachineLearning/sv4gui_MachineLearningUtils.h
+++ b/Code/Source/sv4gui/Modules/MachineLearning/sv4gui_MachineLearningUtils.h
@@ -57,6 +57,8 @@ public:
 
     virtual ~sv4gui_MachineLearningUtils();
 
+    bool ok();
+
     std::string setImage(std::string image_path);
 
     std::vector<std::vector<double>> segmentPathPoint(sv4guiPathElement::sv4guiPathPoint path_point);

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.segmentation/sv4gui_Seg2DEdit.cxx
@@ -219,11 +219,11 @@ void sv4guiSeg2DEdit::CreateQtPartControl( QWidget *parent )
     //ml additions
     setupMLui();
 
-    // If m_ContourGroup is null then the panel is not associated with any 
+    // If m_ContourGroup is null then the panel is not associated with any
     // contour group. This happens when tool panels from previous sessions
     // are created when SV starts.
     //
-    if (m_ContourGroup == nullptr) { 
+    if (m_ContourGroup == nullptr) {
         ui->SinglePathTab->setEnabled(false);
     } else {
         ui->SinglePathTab->setEnabled(true);
@@ -1973,8 +1973,10 @@ void sv4guiSeg2DEdit::initialize(){
         m_imageFilePath = imageElement.attribute("path").toStdString();
     }
 
-    ml_utils = sv4gui_MachineLearningUtils::getInstance("googlenet_c30_train300k_aug10_clean");
-    ml_utils->setImage(m_imageFilePath);
+    if(!ml_init){
+      ml_utils = sv4gui_MachineLearningUtils::getInstance("googlenet_c30_train300k_aug10_clean");
+      ml_utils->setImage(m_imageFilePath);
+    }
 
   }//end if projectfoldernode
 
@@ -2032,6 +2034,12 @@ void sv4guiSeg2DEdit::updatePaths(){
 void sv4guiSeg2DEdit::segmentPaths(){
   //paths
   initialize();
+
+  if ( !ml_utils->ok() ){
+    QMessageBox::warning(NULL,"Machine Learning Error", "Machine Learning segmentation was not loaded properly, please restart or check your installation.");
+    return NULL;
+  }
+
   auto path_folder_node = GetDataStorage()->GetNamedNode("Paths");
   auto paths_list       = GetDataStorage()->GetDerivations(path_folder_node);
 
@@ -2139,6 +2147,11 @@ int index, int n_){
 
 
 sv4guiContour* sv4guiSeg2DEdit::doMLContour(sv4guiPathElement::sv4guiPathPoint path_point){
+  if ( !ml_utils->ok() ){
+    QMessageBox::warning(NULL,"Machine Learning Error", "Machine Learning segmentation was not loaded properly, please restart or check your installation.");
+    return NULL;
+  }
+
   std::vector<std::vector<double>> points = ml_utils->segmentPathPoint(path_point);
 
   if (points.size() <= 0){


### PR DESCRIPTION
Fixes the bug where the segmentation plugin would cause sv to crash if the neural networks weren't present. Now shows an error message instead