### PR TITLE
missing environment variable in sv_wrapper sv_ml python script

### DIFF
--- a/Python/site-packages/sv_ml/sv_wrapper.py
+++ b/Python/site-packages/sv_ml/sv_wrapper.py
@@ -31,6 +31,7 @@
 print("imported svWrapper.py")
 
 import os
+os.environ['CUDA_VISIBLE_DEVICES'] = ''
 import json
 
 print("importing seg_reg modules")


### PR DESCRIPTION
This fixed the machine learning code crashing on Ubuntu.

The environment command is needed to ensure tensorflow doesnt look for GPUs, which won't work unless CUDA is properly configured. With the environment setting it only uses CPU which should work for most people.

It used to be there, not sure how it disappeared, but I added it back.