### PR TITLE
Remove printing messages when parasolid or meshsim plugins are not fo…

### DIFF
--- a/Python/site-packages/sv/__init__.py
+++ b/Python/site-packages/sv/__init__.py
@@ -54,7 +54,7 @@ if sys.version_info < (3,0):
         myDll.initpySolidParasolid()
         import pySolidParasolid as SolidParaSolid
     except:
-        print("ParaSolid is not available!")
+        pass 
     myDll=ctypes.PyDLL('lib_simvascular_repository.' + ext)
     myDll.initpyRepository()
     import pyRepository as Repository
@@ -72,8 +72,7 @@ if sys.version_info < (3,0):
         myDll.initpyMeshSim()
         import pyMeshSim as MeshSim
     except Exception as e:
-        print(e)
-        print("MeshSim is not available!")
+        pass 
     myDLL=ctypes.PyDLL('lib_simvascular_utils.' + ext)
     myDLL.initpyMath()
     import pyMath as Math
@@ -128,8 +127,7 @@ if sys.version_info < (3,0):
         myDll.initpyMeshSimAdapt()
         import pyMeshSimAdapt as MeshSimAdapt
     except Exception as e:
-        print(e)
-        print("MeshSim adaptor is not available!")
+        pass 
     try:
         myDll=ctypes.PyDLL('lib_simvascular_geom.' + ext)
         myDll.initpyGeom()
@@ -168,8 +166,7 @@ else:
         func.restype = ctypes.py_object
         SolidParaSolid = func()
     except Exception as e:
-        print(e)
-        print("ParaSolid is not available!")
+        pass 
     myDll=ctypes.PyDLL('lib_simvascular_repository.' + ext)
     func=myDll.PyInit_pyRepository
     func.restype = ctypes.py_object
@@ -191,8 +188,7 @@ else:
         func.restype = ctypes.py_object
         MeshSim=func()
     except Exception as e:
-        print(e)
-        print("MeshSim is not available!")
+        pass 
     myDLL=ctypes.PyDLL('lib_simvascular_utils.' + ext)
     func=myDLL.PyInit_pyMath
     func.restype = ctypes.py_object
@@ -261,8 +257,7 @@ else:
         func.restype = ctypes.py_object
         MeshSimAdapt=func()
     except Exception as e:
-        print(e)
-        print("MeshSim adaptor is not available!")
+        pass 
     try:
         myDll=ctypes.PyDLL('lib_simvascular_geom.' + ext)
         func=myDll.PyInit_pyGeom


### PR DESCRIPTION
…und.

Most users will not have the Parasolid or MeshSim plugins installed so we should not print messages that they can't be found.