### PR TITLE
Viewing large geometries slow 640

### DIFF
--- a/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.cxx
+++ b/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.cxx
@@ -78,81 +78,91 @@ sv4guiModelVtkMapper3D::~sv4guiModelVtkMapper3D()
 {
 }
 
+//-------------------------
+// GenerateDataForRenderer
+//-------------------------
+//
 void sv4guiModelVtkMapper3D::GenerateDataForRenderer(mitk::BaseRenderer* renderer)
 {
-    mitk::DataNode* node = GetDataNode();
-    if(node==NULL)
-        return;
+    //std::cout << " " << std::endl;
+    //std::cout << "========== sv4guiModelVtkMapper3D  GenerateDataForRenderer ==========" << std::endl;
 
-    LocalStorage *ls = m_LSH.GetLocalStorage(renderer);
+    mitk::DataNode* node = GetDataNode();
+    if (node == NULL) {
+        return;
+    }
+
+    auto localStorage = m_LSH.GetLocalStorage(renderer);
+
+    // Check if the geometry is visible (Data Manager check box).
     bool visible = true;
     GetDataNode()->GetVisibility(visible, renderer, "visible");
-    if(!visible)
-    {
-        ls->m_PropAssembly->VisibilityOff();
+    if (!visible) {
+        localStorage->m_PropAssembly->VisibilityOff();
         return;
     }
 
-    sv4guiModel* model  = const_cast< sv4guiModel* >( this->GetInput() );
-    if(model==NULL)
-    {
-        ls->m_PropAssembly->VisibilityOff();
+    // Get the model.
+    auto model  = const_cast< sv4guiModel* >(this->GetInput());
+    if (model == nullptr) {
+        localStorage->m_PropAssembly->VisibilityOff();
         return;
     }
 
-    int timestep=this->GetTimestep();
-
-    sv4guiModelElement* me=model->GetModelElement(timestep);
-    if(me==NULL)
-    {
-        ls->m_PropAssembly->VisibilityOff();
+    // Get the model element which contains face data and vtk polydata.
+    int timestep = this->GetTimestep();
+    auto modelElem = model->GetModelElement(timestep);
+    if (modelElem == nullptr) {
+        localStorage->m_PropAssembly->VisibilityOff();
         return;
     }
 
-    vtkSmartPointer<vtkPolyData> wholePolyData=me->GetWholeVtkPolyData();
-    if (wholePolyData == NULL)
-    {
-        ls->m_PropAssembly->VisibilityOff();
+    // Get the polydata for the entire model (all faces).
+    //
+    // [TODO:DaveP] I don't think 'wholePolyData'  is ever used. 
+    //
+    auto wholePolyData = modelElem->GetWholeVtkPolyData();
+    if (wholePolyData == NULL) {
+        localStorage->m_PropAssembly->VisibilityOff();
         return;
     }
 
-    bool showWholeSurface=false;
+    bool showWholeSurface = false;
     node->GetBoolProperty("show whole surface", showWholeSurface, renderer);
-
-    bool showFaces=true;
+    bool showFaces = true;
     node->GetBoolProperty("show faces", showFaces, renderer);
 
-    if(me->GetFaceNumber()==0)
-        showWholeSurface=true;
+    // Get the number of model faces.
+    //
+    // [TODO:DaveP] If you delete all of the model faces then showWholeSurface=true
+    // but nothing is displayed.
+    //
+    if (modelElem->GetFaceNumber() == 0) {
+        showWholeSurface = true;
+    }
 
-    if(showWholeSurface)
-        showFaces=false;
+    if (showWholeSurface) {
+        showFaces = false;
+    }
 
-////    bool showWholeSurface=false;
-//    bool showFaces=false;
-
-//    if(me->GetFaceNumber()>0)
-//    {
-//        showWholeSurface=false||forceShowWholeSurface;
-//        showFaces=true;
-//    }else{
-//        showWholeSurface=true;
-//        showFaces=false;
-//    }
-
-    int numProps=ls->m_PropAssembly->GetParts()->GetNumberOfItems();
-    for(int i=0;i<numProps;i++)
-    {
-        vtkProp3D* prop= (vtkProp3D*)ls->m_PropAssembly->GetParts()->GetItemAsObject(i);
-        ls->m_PropAssembly->RemovePart(prop);
+    static int createMapsCount = 0;
+    int numProps = localStorage->m_PropAssembly->GetParts()->GetNumberOfItems();
+    createMapsCount += 1;
+    for (int i = 0; i < numProps; i++) {
+        vtkProp3D* prop = (vtkProp3D*)localStorage->m_PropAssembly->GetParts()->GetItemAsObject(i);
+        localStorage->m_PropAssembly->RemovePart(prop);
     }
 
     float edgeColor[3]= { 0.0f, 0.0f, 1.0f };
     node->GetColor(edgeColor, renderer, "edge color");
-
-    bool showEdges=false;
+    bool showEdges = false;
     node->GetBoolProperty("show edges", showEdges, renderer);
 
+    // Create a mapper and actor for 'wholePolyData'.
+    //
+    // [TODO:DaveP] I don't think this is needed.
+    //
+    /*
 #if VTK_MAJOR_VERSION == 6
     vtkSmartPointer<vtkPainterPolyDataMapper> mapper = vtkSmartPointer<vtkPainterPolyDataMapper>::New();
 #else
@@ -162,91 +172,97 @@ void sv4guiModelVtkMapper3D::GenerateDataForRenderer(mitk::BaseRenderer* rendere
 
     vtkSmartPointer<vtkActor> actor= vtkSmartPointer<vtkActor>::New();
     actor->SetMapper(mapper);
-
     Superclass::ApplyColorAndOpacityProperties( renderer, actor ) ;
     ApplyAllProperties(renderer, mapper, actor);
 
-    if(showEdges)
-    {
+    if (showEdges) {
         actor->GetProperty()->SetEdgeColor(edgeColor[0], edgeColor[1], edgeColor[2]);
         actor->GetProperty()->SetEdgeVisibility(1);
         actor->GetProperty()->SetLineWidth(0.5);
     }
 
-    ls->m_Actor=actor;
+    localStorage->m_Actor=actor;
+    std::cout << "[GenerateDataForRenderer] showWholeSurface: " << showWholeSurface << std::endl;
+    std::cout << "[GenerateDataForRenderer] showFaces: " << showFaces << std::endl;
 
-    if(showWholeSurface)
-    {
-        ls->m_PropAssembly->AddPart(actor );
+    if(showWholeSurface) {
+        localStorage->m_PropAssembly->AddPart(actor );
     }
+    */
 
-    ls->m_FaceActors.clear();
-    if(showFaces)
-    {
-        float selectedColor[3]= { 1.0f, 1.0f, 0.0f };
+    // Display model faces.
+    //
+    localStorage->m_FaceActors.clear();
+
+    if (showFaces) {
+        float selectedColor[3] = { 1.0f, 1.0f, 0.0f };
         node->GetColor(selectedColor, renderer, "face selected color");
+        ResetFaceMapperAndActor();
 
-        for(int i=0;i<me->GetFaces().size();i++)
-        {
-            sv4guiModelElement::svFace* face=me->GetFaces()[i];
-            if(!face)
+        for (int i = 0; i < modelElem->GetFaces().size(); i++) {
+            auto face = modelElem->GetFaces()[i];
+            if (!face) {
                 continue;
+            }
 
-            if(!face->visible)
+            if (!face->visible) {
                 continue;
+            }
 
-            vtkSmartPointer<vtkPolyData> facePolyData=face->vpd;
-            if(!facePolyData)
+            auto facePolyData = face->vpd;
+            if (!facePolyData) {
                 continue;
+            }
+            //std::cout << "[GenerateDataForRenderer] face: " << face << "  facePolyData: " << facePolyData << std::endl;
 
-#if VTK_MAJOR_VERSION == 6
-            vtkSmartPointer<vtkPainterPolyDataMapper> faceMapper = vtkSmartPointer<vtkPainterPolyDataMapper>::New();
-#else
-            vtkSmartPointer<vtkOpenGLPolyDataMapper> faceMapper = vtkSmartPointer<vtkOpenGLPolyDataMapper>::New();
-#endif
+            #if VTK_MAJOR_VERSION == 6
+            auto faceMapper = vtkSmartPointer<vtkPainterPolyDataMapper>::New();
+            #else
+            //auto faceMapper = vtkSmartPointer<vtkOpenGLPolyDataMapper>::New();
+            vtkOpenGLPolyDataMapper* faceMapper;
+            #endif
+
+            vtkActor* faceActor;
+            GetFaceMapperAndActor(face, &faceMapper, &faceActor);
+            //auto faceActor = vtkSmartPointer<vtkActor>::New();
+
             faceMapper->SetInputData(facePolyData);
-
-            vtkSmartPointer<vtkActor> faceActor= vtkSmartPointer<vtkActor>::New();
             faceActor->SetMapper(faceMapper);
 
             ApplyAllProperties(renderer, faceMapper, faceActor);
 
-            if(face->selected){
+            if (face->selected) {
                 faceActor->GetProperty()->SetColor(selectedColor[0], selectedColor[1], selectedColor[2]);
-            }else{
+            } else {
                 faceActor->GetProperty()->SetColor(face->color[0], face->color[1], face->color[2]);
             }
             faceActor->GetProperty()->SetOpacity(face->opacity);
 
-            if(showEdges)
-            {
+            if (showEdges) {
                 faceActor->GetProperty()->SetEdgeColor(edgeColor[0], edgeColor[1], edgeColor[2]);
                 faceActor->GetProperty()->SetEdgeVisibility(1);
                 faceActor->GetProperty()->SetLineWidth(0.51);
             }
 
-            ls->m_PropAssembly->AddPart(faceActor );
-
-            ls->m_FaceActors.push_back(faceActor);
+            localStorage->m_PropAssembly->AddPart(faceActor);
+            localStorage->m_FaceActors.push_back(faceActor);
         }
-
+        UpdateFaceMapperAndActor();
     }
 
-    //show selected cells
-    sv4guiModelElementPolyData* mepd=dynamic_cast<sv4guiModelElementPolyData*>(me);
-    if(mepd&&mepd->GetSelectedCellIDs().size()>0)
-    {
+    // Show selected cells.
+    //
+    auto mepd = dynamic_cast<sv4guiModelElementPolyData*>(modelElem);
+    if (mepd && mepd->GetSelectedCellIDs().size()>0) {
         float selectedColor[3]= { 0.0f, 1.0f, 0.0f };
         node->GetColor(selectedColor, renderer, "cell selected color");
-
-        std::vector<int> cellIDs=mepd->GetSelectedCellIDs();
-
-        vtkSmartPointer<vtkIdTypeArray> ids=vtkSmartPointer<vtkIdTypeArray>::New();
+        std::vector<int> cellIDs = mepd->GetSelectedCellIDs();
+        vtkSmartPointer<vtkIdTypeArray> ids = vtkSmartPointer<vtkIdTypeArray>::New();
         ids->SetNumberOfComponents(1);
-        for(int i=0;i<cellIDs.size();i++)
+        for (int i = 0; i < cellIDs.size(); i++) {
             ids->InsertNextValue(cellIDs[i]);
-
-        vtkSmartPointer<vtkSelectionNode> selectionNode=vtkSmartPointer<vtkSelectionNode>::New();
+        }
+        auto selectionNode = vtkSmartPointer<vtkSelectionNode>::New();
         //Field Type 0 is CELL
         selectionNode->SetFieldType(0);
         //Content Type 4 is INDICES
@@ -288,11 +304,83 @@ void sv4guiModelVtkMapper3D::GenerateDataForRenderer(mitk::BaseRenderer* rendere
 //        cellActor->GetProperty()->SetEdgeVisibility(1);
 //        cellActor->GetProperty()->SetLineWidth(3);
 
-        ls->m_PropAssembly->AddPart(cellActor);
+        localStorage->m_PropAssembly->AddPart(cellActor);
     }
 
     if(visible)
-        ls->m_PropAssembly->VisibilityOn();
+        localStorage->m_PropAssembly->VisibilityOn();
+}
+
+//-----------------------
+// GetFaceMapperAndActor
+//-----------------------
+// Get the vtk mapper and actor for the given face.
+//
+// First try to lookup the mapper and actor in the faceMapperActor[] map. 
+// If it is not there then create them and add them the faceMapperActor[].
+//
+// There does not seem to be a way to tell when face data has changed using mitk
+// so use the face polydata. That works even when an undo is performed.
+//
+void sv4guiModelVtkMapper3D::GetFaceMapperAndActor(sv4guiModelElement::svFace* face, vtkOpenGLPolyDataMapper** faceMapper, 
+        vtkActor** faceActor)
+{
+    vtkOpenGLPolyDataMapper* mapper; 
+    vtkActor* actor;
+    auto facePolyData = face->vpd;
+
+    try {
+        auto mapperActor = this->faceMapperActor.at(facePolyData);
+        mapper = std::get<0>(mapperActor);
+        actor = std::get<1>(mapperActor);
+        std::get<2>(this->faceMapperActor[facePolyData]) = true;
+    } catch (const std::out_of_range& except) {
+        mapper = vtkOpenGLPolyDataMapper::New();
+        actor = vtkActor::New();
+        this->faceMapperActor[facePolyData] = std::make_tuple(mapper, actor, true);
+    }
+
+    *faceMapper = mapper;
+    *faceActor = actor;
+}
+
+//-------------------------
+// ResetFaceMapperAndActor
+//-------------------------
+// Reset the reference tuple element for each entry in the face 
+// Mapper/Actor map to false. 
+//
+void sv4guiModelVtkMapper3D::ResetFaceMapperAndActor()
+{
+    for (auto& elem : this->faceMapperActor) {
+        auto facePolyData = elem.first;
+        auto mapperActor = elem.second;
+        std::get<2>(this->faceMapperActor[elem.first]) = false;
+    }
+}
+
+//--------------------------
+// UpdateFaceMapperAndActor
+//--------------------------
+// Update the face Mapper/Actor map to remove entries that are 
+// no longer being referenced. 
+//
+void sv4guiModelVtkMapper3D::UpdateFaceMapperAndActor()
+{
+    for (auto it = this->faceMapperActor.cbegin(); it != this->faceMapperActor.cend(); ) {
+        auto facePolyData = it->first;
+        auto mapperActor = it->second;
+        bool ref = std::get<2>(mapperActor);
+        if (!ref) {
+            auto mapper = std::get<0>(mapperActor);
+            mapper->Delete();
+            auto actor = std::get<1>(mapperActor);
+            actor->Delete();
+            this->faceMapperActor.erase(it++); 
+        } else {
+            ++it;
+        }
+    }
 }
 
 vtkSmartPointer<vtkActor> sv4guiModelVtkMapper3D::GetWholeSurfaceActor(mitk::BaseRenderer* renderer)

--- a/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.h
+++ b/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.h
@@ -50,6 +50,14 @@
 #include <vtkActor.h>
 #include <vtkPlaneCollection.h>
 #include <vtkSmartPointer.h>
+#include <tuple>
+
+// Define a tuple for storing face mapper/actor in a map for reuse.
+//
+// The bool element is a flag used to identify if a mapper/actor is
+// no longer being used.
+//
+typedef std::tuple<vtkOpenGLPolyDataMapper*, vtkActor*, bool> FaceMapperActor;
 
 /* Properties that can be set for surfaces and influence the sv4guiModelVtkMapper3D are:
   *
@@ -161,6 +169,12 @@ protected:
 
     virtual void CheckForClippingProperty( mitk::BaseRenderer* renderer, mitk::BaseProperty *property );
 
+private:
+    // Define a map for storing face mapper/actor.
+    std::map<vtkSmartPointer<vtkPolyData>, FaceMapperActor> faceMapperActor; 
+    void GetFaceMapperAndActor(sv4guiModelElement::svFace* face, vtkOpenGLPolyDataMapper** faceMapper, vtkActor** faceActor);
+    void ResetFaceMapperAndActor();
+    void UpdateFaceMapperAndActor();
 };
 
 

--- a/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.h
+++ b/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelVtkMapper3D.h
@@ -54,9 +54,10 @@
 
 // Define a tuple for storing face mapper/actor in a map for reuse.
 //
-// The bool element is a flag used to identify if a mapper/actor is
-// no longer being used.
+// The bool element is a reference flag used to identify if a mapper/actor
+// is no longer being used.
 //
+enum FaceMapperActorTupleIndex { MAPPER=0,    ACTOR=1,  REF=2 };
 typedef std::tuple<vtkOpenGLPolyDataMapper*, vtkActor*, bool> FaceMapperActor;
 
 /* Properties that can be set for surfaces and influence the sv4guiModelVtkMapper3D are:


### PR DESCRIPTION
This is a fix for viewing models that contain a large number of faces. The SV mapper code was creating new vtk mappers and actors for each face every time the view was updated (e.g. rotating the view with the mouse).