### PR TITLE
2021-04-20 Bug Fix for CMake on Windows in PythonAPI

### DIFF
--- a/BuildWithMake/MakeHelpers/2019.06/compiler.vs19.16.x64_cygwin.mk
+++ b/BuildWithMake/MakeHelpers/2019.06/compiler.vs19.16.x64_cygwin.mk
@@ -70,7 +70,8 @@ endif
                        /NODEFAULTLIB:libcmtd.lib /NODEFAULTLIB:libcpmtd.lib \
                        /NODEFAULTLIB:msvcrtd.lib \
                       /MACHINE:X64 -subsystem:console
-
+    # add verbose flag to debug linking issues (lists all search libraries)
+    #GLOBAL_LFLAGS   += /VERBOSE:LIB
     SHARED_LFLAGS   = /DLL $(GLOBAL_LFLAGS) $(CXX_LIBS)
     STATIC_FLAG     =
     DYNAMIC_FLAG    =
@@ -83,5 +84,6 @@ endif
     LIBCMD          = lib
     SVLIBFLAG       =lib
     LIBLINKEXT      =.lib
-#    SV_QUIET_FLAG   = @
+    # comment out the SV_QUIET_FLAG to get more debug info at compiler time
+    SV_QUIET_FLAG   = @
 endif

--- a/Code/Source/PythonAPI/CMakeLists.txt
+++ b/Code/Source/PythonAPI/CMakeLists.txt
@@ -58,8 +58,8 @@ list (APPEND CXXSRCS
 add_library(${lib} ${SV_LIBRARY_TYPE} ${CXXSRCS})
 
 # hack to define US_MODULE_NAME because we are including sv4gui_ContourGroupIO.h
-set_property(TARGET ${lib} PROPERTY US_MODULE_NAME ${lib_module_name})
-set_property(TARGET ${lib} APPEND PROPERTY COMPILE_DEFINITIONS US_MODULE_NAME=${lib_module_name})
+set_property(TARGET ${lib} PROPERTY US_MODULE_NAME sv4guiModulePythonAPI)
+set_property(TARGET ${lib} APPEND PROPERTY COMPILE_DEFINITIONS US_MODULE_NAME=sv4guiModulePythonAPI)
 
 target_link_libraries(${lib} ${PYTHON_LIBRARY} ${org_sv_pythondatanodes} )
 


### PR DESCRIPTION
BUG: fixed bug in CMake build for PythonAPI (missing US_MODULE_NAME)
BUILD: commented out a few compile and link flags on windows for less verbose output by default