### PR TITLE
Add svZeroDSolver (#853)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Code/Licensed/ParasolidSolidModel"]
 	path = Code/Licensed/ParasolidSolidModel
 	url = git@github.com:SimVascular/LicensedPlugin-ParasolidSolidModel.git
+[submodule "Python/site-packages/svZeroDSolver"]
+	path = Python/site-packages/svZeroDSolver
+	url = git@github.com:SimVascular/svZeroDSolver.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Code/Licensed/ParasolidSolidModel"]
 	path = Code/Licensed/ParasolidSolidModel
-	url = git@github.com:SimVascular/LicensedPlugin-ParasolidSolidModel.git
+	url = ../LicensedPlugin-ParasolidSolidModel.git
 [submodule "Python/site-packages/svZeroDSolver"]
 	path = Python/site-packages/svZeroDSolver
-	url = git@github.com:SimVascular/svZeroDSolver.git
+	url = ../svZeroDSolver.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,3 +215,19 @@ ExternalProject_Add(SimVascular
     ${SV_ADDITIONAL_CMAKE_ARGS}
     )
 #-----------------------------------------------------------------------------
+
+# add git submodules
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
+# Update submodules as needed
+    option(GIT_SUBMODULE "Check submodules during build" ON)
+    if(GIT_SUBMODULE)
+        message(STATUS "Submodule update")
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+                        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                        RESULT_VARIABLE GIT_SUBMOD_RESULT)
+        if(NOT GIT_SUBMOD_RESULT EQUAL "0")
+            message(FATAL_ERROR "git submodule update --init failed with ${GIT_SUBMOD_RESULT}, please checkout submodules")
+        endif()
+    endif()
+endif()


### PR DESCRIPTION
Closes #853. Note the relative paths in ```.gitmodules``` to keep the same access method as in the parent repository.

See for reference: https://cliutils.gitlab.io/modern-cmake/chapters/projects/submodule.html