### PR TITLE
Change to look for OpenMPI rather than MPICH for svsolver MPI.

### DIFF
--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.simulation/sv4gui_MPIPreferences.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.simulation/sv4gui_MPIPreferences.cxx
@@ -69,9 +69,9 @@ sv4guiMPIPreferences::~sv4guiMPIPreferences()
 {
 }
 
-//---------------------------
+//-----------------------
 // InitializeMPILocation
-//---------------------------
+//-----------------------
 // Find the location of solver binaries and mpiexec.
 //
 // The the full binary path is displayed in the SimVascular 

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.simulation/sv4gui_SimulationView.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.simulation/sv4gui_SimulationView.cxx
@@ -1678,7 +1678,7 @@ void sv4guiSimulationView::RunJob()
         if(m_UseMPI) {
           // Check that the solver binaries are valid.
           CheckSolver();
-          // Check that mpi is installed and that the implementation is MPICH or MSMPI.
+          // Check that mpi is installed and that the implementation is OpenMPI or MSMPI.
           CheckMpi();
         } else {
 	  CheckSolverNOMPI();
@@ -1924,13 +1924,12 @@ void sv4guiSimulationView::CheckSolverNOMPI()
     }
 }
 
-
 //----------
 // CheckMpi
 //----------
 // Check for valid mpiexec binary and MPI implementation.
 //
-// svSolver needs the MPICH MPI implementation.
+// svSolver needs the OpenMPI implementation.
 //
 void sv4guiSimulationView::CheckMpi()
 {
@@ -1961,9 +1960,9 @@ void sv4guiSimulationView::CheckMpi()
     #ifndef WIN32
     // Check the MPI implementation.
     auto mpiName = m_DefaultMPIPrefs.GetMpiImplementationName();
-    if (m_MpiImplementation != sv4guiMPIPreferences::MpiImplementation::MPICH) {
-       QString msg1 = "svSolver requires MPICH but an MPICH MPI implementation was not found.\n";
-       QString msg2 = "Please install MPICH MPI or set the location of an MPICH mpiexec in the Preferences->SimVascular Simulation page.";
+    if (m_MpiImplementation != sv4guiMPIPreferences::MpiImplementation::OpenMPI) {
+       QString msg1 = "svSolver requires OpenMPI but an OpenMPI MPI implementation was not found.\n";
+       QString msg2 = "Please install OpenMPI MPI or set the location of an OpenMPI mpiexec in the Preferences->SimVascular Simulation page.";
        QMessageBox::warning(m_Parent, MsgTitle, msg1+msg2);
        throw exception; 
     }


### PR DESCRIPTION
svSolver is now built using OpenMPI so the `Simulation` tool should now check that OpenMPI is installed.