### PR TITLE
Add creating a ROMSimulations dir if a Simulations1d dir is not present.

### DIFF
--- a/Code/Source/sv4gui/Modules/ProjectManagement/sv4gui_ProjectManager.cxx
+++ b/Code/Source/sv4gui/Modules/ProjectManagement/sv4gui_ProjectManager.cxx
@@ -2120,11 +2120,14 @@ void sv4guiProjectManager::CreatePlugin(mitk::DataStorage::Pointer dataStorage, 
 //
 void sv4guiProjectManager::UpdateSimulations1dFolder(const QString& projPath, const QString& romSimFolderName)
 {
+  // If there is no 'Simulations1d' directory then just 
+  // create a 'ROMSimulations' directory.
+  //
   QDir project_dir(projPath);
   auto sim1dFolder = project_dir.absoluteFilePath("Simulations1d");
-
   QFileInfo checkFile(sim1dFolder);
   if (!checkFile.exists()) { 
+    project_dir.mkdir("ROMSimulations"); 
     return; 
   }
 


### PR DESCRIPTION
SV currently renames a project's `Simulations1d` directory to `ROMSimulations` but for old SV projects there is no `Simulations1d` directory. Add creating the `ROMSimulations` if there is no `Simulations1d` directory.