### PR TITLE
Rom convert results freezes sv 912

### DIFF
--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/Makefile
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/Makefile
@@ -47,6 +47,7 @@ CXXFLAGS = $(GLOBAL_CXXFLAGS) \
            -DUS_MODULE_NAME=sv4guiModuleROMSimulation
 
 HDRS	= \
+    sv4gui_ConvertProcessHandlerROM.h \
     sv4gui_ROMSimJobCreate.h \
     sv4gui_ROMSimJobCreateAction.h \
     sv4gui_CapBCWidgetROM.h \
@@ -67,6 +68,7 @@ HDRS	= \
     sv4gui_SolverProcessHandlerROM.h
 
 CXXSRCS	= \
+    sv4gui_ConvertProcessHandlerROM.cxx \
     sv4gui_ROMSimJobCreate.cxx \
     sv4gui_ROMSimJobCreateAction.cxx \
     sv4gui_CapBCWidgetROM.cxx \

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/files.cmake
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/files.cmake
@@ -30,6 +30,7 @@
 
 set(CPP_FILES
     sv4gui_ConvertProcessHandlerROM.cxx
+    sv4gui_ConvertWorkerROM.cxx
     sv4gui_ROMSimJobCreate.cxx
     sv4gui_ROMSimJobCreateAction.cxx
     sv4gui_CapBCWidgetROM.cxx
@@ -52,6 +53,7 @@ set(CPP_FILES
 
 set(MOC_H_FILES
     sv4gui_ConvertProcessHandlerROM.h
+    sv4gui_ConvertWorkerROM.h
     sv4gui_ROMSimJobCreate.h
     sv4gui_ROMSimJobCreateAction.h
     sv4gui_CapBCWidgetROM.h

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/files.cmake
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/files.cmake
@@ -29,6 +29,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 set(CPP_FILES
+    sv4gui_ConvertProcessHandlerROM.cxx
     sv4gui_ROMSimJobCreate.cxx
     sv4gui_ROMSimJobCreateAction.cxx
     sv4gui_CapBCWidgetROM.cxx
@@ -50,6 +51,7 @@ set(CPP_FILES
 )
 
 set(MOC_H_FILES
+    sv4gui_ConvertProcessHandlerROM.h
     sv4gui_ROMSimJobCreate.h
     sv4gui_ROMSimJobCreateAction.h
     sv4gui_CapBCWidgetROM.h

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertProcessHandlerROM.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertProcessHandlerROM.cxx
@@ -1,0 +1,261 @@
+/* Copyright (c) Stanford University, The Regents of the University of
+ *               California, and others.
+ *
+ * All Rights Reserved.
+ *
+ * See Copyright-SimVascular.txt for additional details.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sv4gui_ConvertProcessHandlerROM.h"
+
+#include "sv4gui_TableCapDelegateROM.h"
+#include "sv4gui_TableSolverDelegateROM.h"
+#include "sv4gui_MitkMesh.h"
+#include "sv4gui_MeshLegacyIO.h"
+#include "sv4gui_ROMSimulationUtils.h"
+
+#include <QmitkStdMultiWidgetEditor.h>
+#include <mitkNodePredicateDataType.h>
+#include <mitkUndoController.h>
+#include <mitkSliceNavigationController.h>
+#include <mitkProgressBar.h>
+#include <mitkStatusBar.h>
+#include <mitkGenericProperty.h>
+
+#include <berryIPreferencesService.h>
+#include <berryIPreferences.h>
+#include <berryPlatform.h>
+
+#include <usModuleRegistry.h>
+
+#include <QTreeView>
+#include <QInputDialog>
+#include <QMessageBox>
+#include <QDomDocument>
+#include <QDomElement>
+#include <QDir>
+#include <QProcess>
+#include <QFileDialog>
+#include <QThread>
+#include <QSettings>
+#include <QScrollArea>
+#include <QVBoxLayout>
+#include <QApplication>
+
+sv4guiConvertProcessHandlerROM::sv4guiConvertProcessHandlerROM(QProcess* process, int startStep, int totalSteps, 
+  QString runDir, QWidget* parent) : m_Process(process) , m_StartStep(startStep) , m_TotalSteps(totalSteps), 
+  m_RunDir(runDir) , m_Parent(parent) , m_Timer(NULL)
+{
+}
+
+sv4guiConvertProcessHandlerROM::~sv4guiConvertProcessHandlerROM()
+{
+    if(m_Process) {
+        delete m_Process;
+    }
+
+    if(m_Timer) {
+        delete m_Timer;
+    }
+}
+
+//--------------
+// ProcessError
+//--------------
+// Display information for a process that has failed with an unknown error.
+//
+// This handles jobs that for some reason were not able to start.,
+//
+void sv4guiConvertProcessHandlerROM::ProcessError(QProcess::ProcessError error)
+{
+  MITK_ERROR << "Convert results error = " << error;
+  QString title = "";
+  QString text = "";
+  QString status = "Convert results failed";
+  QMessageBox::Icon icon = QMessageBox::Warning;
+  QMessageBox messageBox(NULL); 
+
+  if (error == QProcess::FailedToStart) {
+    title = "Convert results failed";
+    text = "Unable to execute the convert results script.";
+    MITK_ERROR << text; 
+  } else {
+    title = "Convert results failed";
+    text = "Unknown error return code " + error; 
+    MITK_ERROR << text; 
+  }
+
+  messageBox.setWindowTitle(title);
+  messageBox.setText(text+"                                                                                         ");
+  messageBox.setIcon(icon);
+
+  if (m_Process) {
+    auto details = m_Process->readAllStandardOutput()+"\n"+m_Process->readAllStandardError();
+    messageBox.setDetailedText(m_Process->readAllStandardOutput()+"\n"+m_Process->readAllStandardError());
+  }
+
+  messageBox.exec();
+
+/*
+  sv4guiMitkROMSimJob* mitkJob = dynamic_cast<sv4guiMitkROMSimJob*>(m_JobNode->GetData());
+  if(mitkJob) {
+    mitkJob->SetStatus(status.toStdString());
+  }
+
+  m_JobNode->SetBoolProperty("running",false);
+  m_JobNode->SetDoubleProperty("running progress", 0);
+*/
+
+  mitk::StatusBar::GetInstance()->DisplayText(status.toStdString().c_str());
+
+  deleteLater();
+}
+
+//-------
+// Start
+//-------
+// Start a convert results process.
+//
+void sv4guiConvertProcessHandlerROM::Start()
+{
+    if (m_Process == NULL) {
+        return;
+    }
+
+    // Set callback for if an error occurs with the process.
+    connect(m_Process, &QProcess::errorOccurred, this, &sv4guiConvertProcessHandlerROM::ProcessError);
+
+    // Set callback for the finished process. 
+    connect(m_Process,SIGNAL(finished(int,QProcess::ExitStatus)), this, SLOT(AfterProcessFinished(int,QProcess::ExitStatus)));
+
+    // Start the process.
+    m_Process->start();
+
+    m_Timer = new QTimer(this);
+    connect(m_Timer, SIGNAL(timeout()), this, SLOT(UpdateStatus()));
+    m_Timer->start(3000);
+}
+
+//-------------
+// KillProcess
+//-------------
+//
+void sv4guiConvertProcessHandlerROM::KillProcess()
+{
+    if (m_Process) {
+        m_Process->kill();
+    }
+}
+
+//----------------------
+// AfterProcessFinished
+//----------------------
+// Display information for a finished process.
+//
+void sv4guiConvertProcessHandlerROM::AfterProcessFinished(int exitCode, QProcess::ExitStatus exitStatus)
+{
+    if (!m_Process) {
+        return;
+    }
+
+    QString title = "ROM Simulation convert results";
+    QMessageBox::Icon icon = QMessageBox::NoIcon;
+    QMessageBox mb(NULL); 
+    QString status = "";
+
+    QString text = "Convert results ";
+    auto exitCodeString = QString::number(exitCode); 
+    QString stdError = QString(m_Process->readAllStandardError());
+    QString stdOutput = QString(m_Process->readAllStandardOutput());
+
+    // Show convert results status.
+    //
+    if (exitCode != 0) {
+        text += "has failed with non-zero exit code " + exitCodeString + ".";
+        icon = QMessageBox::Warning;
+        status = "Convert results failed";
+        MITK_WARN << "Exit code: " + exitCodeString; 
+        MITK_WARN << "Error: " + stdError; 
+    } else if (exitStatus == QProcess::NormalExit) { 
+        text += "has finished.";
+        icon = QMessageBox::Information;
+        status = "Convert results done";
+    } else {
+        text += "has crashed.";
+        icon = QMessageBox::Warning;
+        status ="Convert results failed";
+    }
+
+    mb.setWindowTitle(title);
+    mb.setText(text+"                                                                                         ");
+    mb.setIcon(icon);
+    mb.setDetailedText(stdOutput + "\n" + stdError);
+    mb.exec();
+
+    // Set job status. 
+    /*
+    sv4guiMitkROMSimJob* mitkJob = dynamic_cast<sv4guiMitkROMSimJob*>(m_JobNode->GetData());
+    if (mitkJob) {
+        mitkJob->SetStatus(status.toStdString());
+    }
+    */
+    mitk::StatusBar::GetInstance()->DisplayText(status.toStdString().c_str());
+
+    // Set job progress. 
+    //m_JobNode->SetBoolProperty("running",false);
+    //m_JobNode->SetDoubleProperty("running progress", 0);
+
+    // Write the convert results log file.
+    //
+    std::string solverLogFileName;
+    std::string outputDir;
+    //m_JobNode->GetStringProperty("output directory", outputDir);
+    //m_JobNode->GetStringProperty("solver log file", solverLogFileName);
+    //MITK_INFO << "[sv4guiConvertProcessHandlerROM::AfterProcessFinished] " << "outputDir: " << outputDir;
+
+    /*
+    auto logFileName = outputDir + "/" + solverLogFileName;
+    QFile logFileWriter(QString(logFileName.c_str()));
+    MITK_INFO << "[sv4guiConvertProcessHandlerROM::AfterProcessFinished] " << "solver log file: " << logFileName;
+
+    if (logFileWriter.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream output(&logFileWriter);
+        output << stdOutput;
+        output << stdError;
+        logFileWriter.close();
+    } else {
+        MITK_INFO << "Can't write solver log file '" << logFileName << "'";
+    }
+    */
+
+    deleteLater();
+}
+
+void sv4guiConvertProcessHandlerROM::UpdateStatus()
+{
+    //QString status = QString::fromStdString(m_JobNode->GetName())+": running";
+    //mitk::StatusBar::GetInstance()->DisplayText(status.toStdString().c_str());
+}

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertProcessHandlerROM.h
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertProcessHandlerROM.h
@@ -1,0 +1,91 @@
+/* Copyright (c) Stanford University, The Regents of the University of
+ *               California, and others.
+ *
+ * All Rights Reserved.
+ *
+ * See Copyright-SimVascular.txt for additional details.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SV4GUI_CONVERT_PROCESS_HANDLER_ROM_H
+#define SV4GUI_CONVERT_PROCESS_HANDLER_ROM_H 
+
+#include "sv4gui_ProcessHandler.h"
+
+#include "sv4gui_MitkROMSimJob.h"
+#include "sv4gui_Model.h"
+#include "sv4gui_CapBCWidgetROM.h"
+#include "sv4gui_SplitBCWidgetROM.h"
+#include "sv4gui_QmitkFunctionality.h"
+
+#include "sv4gui_ModelDataInteractor.h"
+
+#include <berryIBerryPreferences.h>
+
+#include <QWidget>
+#include <QStandardItemModel>
+#include <QProcess>
+#include <QMessageBox>
+
+class sv4guiConvertProcessHandlerROM : public QObject
+{
+    Q_OBJECT
+
+public:
+    sv4guiConvertProcessHandlerROM(QProcess* process, int startStep, int totalSteps, QString runDir, QWidget* parent=NULL);
+    virtual ~sv4guiConvertProcessHandlerROM();
+
+    void Start();
+
+    void KillProcess();
+
+public slots:
+
+    void AfterProcessFinished(int exitCode, QProcess::ExitStatus exitStatus);
+
+    void UpdateStatus();
+
+    void ProcessError(QProcess::ProcessError error);
+
+private:
+
+    QProcess* m_Process;
+
+    QWidget* m_Parent;
+
+    QMessageBox* m_MessageBox;
+
+    // mitk::DataNode::Pointer m_JobNode;
+
+    QTimer* m_Timer;
+
+    int m_StartStep;
+
+    int m_TotalSteps;
+
+    QString m_RunDir;
+};
+
+#endif // SV4GUI_SOLVERPROCESSHANDLERROM_H

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertWorkerROM.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertWorkerROM.cxx
@@ -1,0 +1,155 @@
+/* Copyright (c) Stanford University, The Regents of the University of
+ *               California, and others.
+ *
+ * All Rights Reserved.
+ *
+ * See Copyright-SimVascular.txt for additional details.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// The sv4guiConvertWorkerROM class methods defined here are used to convert ROM simulation 
+// results in a QThread so not to freeze SimVascular while executing.
+//
+// The 'sv_rom_extract_results' Python module 'extract_results.py' script is directly exectuted
+// using the CPython API PyObject_Call() function.
+//
+// Because Qt widgets can't be executed in a QThread, QMessage widgets used to display conversion
+// success/failure messages must be called outside of a sv4guiConvertWorkerROM object. The
+// QMessage widgets are therefore called in sv4guiROMSimulationView::ShowConvertWorkerMessage().
+//
+// The sv4guiConvertWorkerROM object's 'finished', 'error', and 'showMessage' signals are connected
+// to the sv4guiROMSimulationView class 'ShowConvertWorkerMessage', 'ConvertWorkerError' and
+// 'ConvertWorkerFinished' methods in sv4guiROMSimulationPythonConvert::ConvertResultsWorker().
+// The sv4guiConvertWorkerROM emit statements pass conversion status messages to them.
+//
+#include <Python.h>
+
+#include "sv4gui_ConvertWorkerROM.h"
+#include "sv4gui_ROMSimulationPythonConvert.h"
+#include "sv4gui_ROMSimulationView.h"
+
+#include <mitkLogMacros.h>
+
+#include <QMessageBox>
+
+#include <iostream>
+#include <map>
+
+//------------------------
+// sv4guiConvertWorkerROM
+//------------------------
+//
+sv4guiConvertWorkerROM::sv4guiConvertWorkerROM()
+{
+  m_Thread = nullptr;
+}
+
+sv4guiConvertWorkerROM::~sv4guiConvertWorkerROM()
+{
+  m_Thread->quit();
+}
+
+//---------
+// convert
+//---------
+// Convert ROM solver results into a general format for plotting. 
+//
+// This executes the Python script the CPython PyObject_Call() function.
+//
+void sv4guiConvertWorkerROM::convertResults()
+{
+  sv4guiROMSimulationPythonConvertParamNames paramNames;
+
+  // Import the convert ROM solver results module.
+  //
+  auto pyName = PyUnicode_DecodeFSDefault((char*)m_ModuleName.c_str());
+  auto pyModule = PyImport_Import(pyName);
+
+  if (pyModule == nullptr) {
+      auto msg = "Unable to load the Python '" + QString(m_ModuleName.c_str()) + "' module.";
+      emit error(msg);
+  }
+
+  // Get the module interface function that executes 
+  // module functions based on input arguments. 
+  //
+  auto pyFuncName = (char*)"run_from_c";
+  auto pyDict = PyModule_GetDict(pyModule);
+  auto pyFunc = PyDict_GetItemString(pyDict, (char*)pyFuncName);
+
+  if (!PyCallable_Check(pyFunc)) {
+      auto msg = "Can't find the function '" + QString(pyFuncName) + "' in the '" + QString(m_ModuleName.c_str()) + "' module.";
+      emit error(msg);
+      return;
+  }
+
+  // Create an argument containing the output directory.
+  // This is used to write a script log file to the
+  // solver job directory.
+  //
+  auto dummyArgs = PyTuple_New(1);
+  auto dummyValue = PyUnicode_DecodeFSDefault(m_OutputDirectory.c_str());
+  PyTuple_SetItem(dummyArgs, 0, dummyValue);
+
+  // Create the **kwarg arguments that are the input arguments to the module.
+  auto kwargs = PyDict_New();
+  for (auto const& param : m_ParameterValues) {
+      PyDict_SetItemString(kwargs, param.first.c_str(), PyUnicode_DecodeFSDefault(param.second.c_str()));
+  }
+
+  // Execute the Python script.
+  auto result = PyObject_Call(pyFunc, dummyArgs, kwargs);
+
+  // Check for errors.
+  PyErr_Print();
+
+  // If the convert results files was not successful then
+  // then display error messages and the script log file.
+  //
+  // Search for the Python logger ERROR or WARNING messages in the 
+  // returned result to determine if the script failed.
+  //
+  // The 'emit showMessage(errorMsg, msg)' statement sends a message to 
+  // sv4guiROMSimulationView::ShowConvertWorkerMessage().
+  //
+  if (result) {
+      auto uResult = PyUnicode_FromObject(result);
+      auto sResult = std::string(PyUnicode_AsUTF8(uResult));
+      bool errorMsg;
+      QString msg = QString(sResult.c_str());
+
+      if (sResult.find("Error") != std::string::npos) {
+          errorMsg = true;
+      } else {
+          errorMsg = false;
+      }
+
+      emit showMessage(errorMsg, msg);
+  }
+
+  // Signal the thead is finished;
+  emit finished();
+}
+

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertWorkerROM.h
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ConvertWorkerROM.h
@@ -1,0 +1,91 @@
+/* Copyright (c) Stanford University, The Regents of the University of
+ *               California, and others.
+ *
+ * All Rights Reserved.
+ *
+ * See Copyright-SimVascular.txt for additional details.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject
+ * to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ * OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef SV4GUI_CONVERT_WORKER_ROM_H
+#define SV4GUI_CONVERT_WORKER_ROM_H 
+
+/*
+#include "sv4gui_ProcessHandler.h"
+
+#include "sv4gui_MitkROMSimJob.h"
+#include "sv4gui_Model.h"
+#include "sv4gui_CapBCWidgetROM.h"
+#include "sv4gui_SplitBCWidgetROM.h"
+#include "sv4gui_QmitkFunctionality.h"
+
+#include "sv4gui_ModelDataInteractor.h"
+
+#include <berryIBerryPreferences.h>
+
+#include <QWidget>
+#include <QStandardItemModel>
+#include <QThread>
+#include <QMessageBox>
+*/
+#include <QObject>
+#include <QThread>
+
+#include <map>
+#include <string>
+
+//------------------------
+// sv4guiConvertWorkerROM
+//------------------------
+// The sv4guiConvertWorkerROM class is used to convert ROM simulation results in a QThread.
+//
+class sv4guiConvertWorkerROM : public QObject 
+{
+  Q_OBJECT
+
+  public:
+    sv4guiConvertWorkerROM();
+    ~sv4guiConvertWorkerROM();
+    void SetModuleName(const std::string& moduleName) { m_ModuleName = moduleName; }
+    void SetParameterValues(const std::map<std::string,std::string>& parameterValues) { m_ParameterValues = parameterValues; }
+    void SetOutputDirectory(const std::string& outputDirectory) { m_OutputDirectory = outputDirectory; }
+    void SetThread(QThread* thread) { m_Thread = thread; }
+
+  public slots:
+    void convertResults();
+
+  signals:
+    void finished();
+    void error(const QString msg);
+    void showMessage(const bool errorMsg, const QString& msg);
+
+  private:
+    std::string m_OutputDirectory;
+    std::map<std::string,std::string> m_ParameterValues;
+    std::string m_ModuleName;
+    QThread* m_Thread;
+};
+
+#endif 

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.cxx
@@ -34,11 +34,13 @@
 #include <map>
 #include "sv4gui_ROMSimulationPythonConvert.h"
 #include "sv4gui_ConvertProcessHandlerROM.h"
+#include "sv4gui_ConvertWorkerROM.h"
 
 #include <mitkLogMacros.h>
 
 #include <QMessageBox>
 #include <QProcess>
+#include <QObject>
 
 #include <vtkXMLPolyDataWriter.h>
 
@@ -60,6 +62,33 @@ sv4guiROMSimulationPythonConvert::~sv4guiROMSimulationPythonConvert()
 {
 }
 
+//----------------------
+// ConvertResultsWorker
+//----------------------
+// Set the data and event connections for a sv4guiConvertWorkerROM object
+// used to convert ROM simulation results in a QThread.
+//
+bool sv4guiROMSimulationPythonConvert::ConvertResultsWorker(sv4guiConvertWorkerROM* convertWorker, const std::string outputDirectory)
+{
+  // Set work values.
+  convertWorker->SetModuleName(m_PythonModuleName);
+  convertWorker->SetParameterValues(m_ParameterValues);
+  convertWorker->SetOutputDirectory(outputDirectory);
+
+  // Create a thread.
+  auto thread = new QThread();
+  convertWorker->SetThread(thread);
+
+  // Connect thread and sv4guiConvertWorkerROM events with callbacks.
+  QObject::connect(thread, &QThread::started, convertWorker, &sv4guiConvertWorkerROM::convertResults);
+  QObject::connect(convertWorker, &sv4guiConvertWorkerROM::finished, thread, &QThread::quit);
+  QObject::connect(thread, &QThread::finished, thread, &QThread::deleteLater);
+
+  // Move the sv4guiConvertWorkerROM to the thread and start it.
+  convertWorker->moveToThread(thread);
+  thread->start();
+}
+
 //-----------------------
 // ConvertResultsProcess
 //-----------------------
@@ -67,27 +96,18 @@ sv4guiROMSimulationPythonConvert::~sv4guiROMSimulationPythonConvert()
 //
 // This executes the Python script as a separate process using the Python interpreter. 
 //
+// Note: This did not work because VTK could not be successfully imported in Python.
+// The code is not used but keep it around just in case it might be useful.
+//
 bool sv4guiROMSimulationPythonConvert::ConvertResultsProcess(const std::string outputDirectory)
 {
-  std::cout << "[ConvertResultsProcess] " << std::endl;
-  std::cout << "========== sv4guiROMSimulationPythonConvert::ConvertResultsProcess ========== " << std::endl;
   sv4guiROMSimulationPythonConvertParamNames params;
 
   auto resultsDir = m_ParameterValues[params.RESULTS_DIRECTORY];
   auto outDir = m_ParameterValues[params.OUTPUT_DIRECTORY];
 
-  std::cout << "[ConvertResultsProcess] resultsDir: " << resultsDir << std::endl;
-  std::cout << "[ConvertResultsProcess] outDir: " << outDir << std::endl;
-
   auto pyName = PyUnicode_DecodeFSDefault((char*)m_PythonModuleName.c_str());
   auto pyModule = PyImport_Import(pyName);
-  std::cout << "[ConvertResultsProcess] m_PythonModuleName: " << m_PythonModuleName << std::endl;
-
-  //std::string programName = "/Users/parkerda/software/ktbolt/SimVascular/build/Externals-build/svExternals/bin/python-3.5.5/bin/python";
-  //std::string scriptName = "extract_results.py";
-  //std::string scriptName = "/Users/parkerda/software/ktbolt/SimVascular/Python/site-packages/sv_rom_extract_results/extract_results.py";
-  std::string scriptName = "sv_rom_extract_results.extract_results";
-  //std::string scriptName = "sv_rom_extract_results.bob";
 
   // Create a process and set program to execute and the directory it will execute from.
   QProcess* convertProcess = new QProcess();
@@ -109,23 +129,18 @@ bool sv4guiROMSimulationPythonConvert::ConvertResultsProcess(const std::string o
   auto envLibPath = std::getenv("DYLD_LIBRARY_PATH");
   convertProcessEnv.insert("DYLD_LIBRARY_PATH", envLibPath); 
 
-  std::cout << "[ConvertResultsProcess] envPythonHome: " << envPythonHome << std::endl;
-  std::cout << "[ConvertResultsProcess] envPythonPath: " << envPythonPath << std::endl;
-  std::cout << "[ConvertResultsProcess] envLibPath: " << envLibPath << std::endl;
-
   convertProcess->setProcessEnvironment(convertProcessEnv);
-
-  QStringList arguments;
-  arguments << "-m";
-  arguments << QString(scriptName.c_str());
 
   // Create the arguments for Python script.
   //
   // Arguments have the format 
   //   --NAME VALUE
   //
-  std::cout << "[ConvertResultsProcess] " << std::endl;
-  std::cout << "[ConvertResultsProcess] Add arguments ... " << std::endl;
+  std::string scriptName = "sv_rom_extract_results.extract_results";
+  QStringList arguments;
+  arguments << "-m";
+  arguments << QString(scriptName.c_str());
+
   for (auto const& param : m_ParameterValues) {
       // Set the argument name.
       auto conv_arg = "--" + QString(param.first.c_str()).replace("_", "-");
@@ -148,7 +163,6 @@ bool sv4guiROMSimulationPythonConvert::ConvertResultsProcess(const std::string o
       if (arg_value != "true") { 
           arguments << QString(arg_value.c_str());
       }
-      std::cout << "[ConvertResultsProcess] " << conv_arg << "   " << arg_value << std::endl; 
   }
   convertProcess->setArguments(arguments);
 
@@ -159,115 +173,6 @@ bool sv4guiROMSimulationPythonConvert::ConvertResultsProcess(const std::string o
   handler->Start();
 
   return true;
-
-}
-
-//----------------
-// ConvertResults
-//----------------
-// Convert ROM solver results into a general format for plotting. 
-//
-// This executes the Python script the Python PyObject_Call() function.
-//
-// Example script arguments: 
-//
-//    python extract_results.py          \
-//      --results-directory ${res_dir}   \
-//      --solver-file-name ${file}       \
-//      --outlet-segments                \
-//      --data-names ${data_names}       \
-//      --time-range ${time_range}       \
-//      --output-directory ${out_dir}    \
-//      --output-file-name ${out_file}   \
-//      --output-format ${out_format}
-//
-bool sv4guiROMSimulationPythonConvert::ConvertResults(const std::string outputDirectory)
-{
-  std::string msg = "[sv4guiROMSimulationPythonConvert::ConvertResults] ";
-  MITK_INFO << msg << "---------- ConvertResults ----------";
-  sv4guiROMSimulationPythonConvertParamNames paramNames;
-
-  // Import the convert 1D solver results module.
-  //
-  auto pyName = PyUnicode_DecodeFSDefault((char*)m_PythonModuleName.c_str());
-  auto pyModule = PyImport_Import(pyName);
-
-  if (pyModule == nullptr) {
-      auto msg = "Unable to load the Python '" + QString(m_PythonModuleName.c_str()) + "' module.";
-      MITK_ERROR << msg;
-      //QMessageBox::warning(NULL, sv4guiROMSimulationView::MsgTitle, msg);
-      return false;
-  } 
-
-  // Get the module interface function that executes 
-  // module functions based on input arguments. 
-  //
-  auto pyFuncName = (char*)"run_from_c";
-  auto pyDict = PyModule_GetDict(pyModule);
-  auto pyFunc = PyDict_GetItemString(pyDict, (char*)pyFuncName);
-
-  if (!PyCallable_Check(pyFunc)) {
-      auto msg = "Can't find the function '" + QString(pyFuncName) + "' in the '" + QString(m_PythonModuleName.c_str()) + "' module.";
-      MITK_ERROR << msg;
-      //QMessageBox::warning(NULL, sv4guiROMSimulationView::MsgTitle, msg);
-      return false;
-  }
-
-  // Create an argument containing the output directory.
-  // This is used to write a script log file to the
-  // solver job directory.
-  //
-  auto dummyArgs = PyTuple_New(1);
-  auto dummyValue = PyUnicode_DecodeFSDefault(outputDirectory.c_str());
-  PyTuple_SetItem(dummyArgs, 0, dummyValue);
-
-  // Create the **kwarg arguments that are the input arguments to the module.
-  //
-  MITK_INFO << msg << "Add arguments ... ";
-  auto kwargs = PyDict_New();
-  for (auto const& param : m_ParameterValues) {
-      MITK_INFO << msg << param.first << "   " << "'" << param.second << "'"; 
-      PyDict_SetItemString(kwargs, param.first.c_str(), PyUnicode_DecodeFSDefault(param.second.c_str()));
-  }
-  MITK_INFO << msg << "Done.";
-
-  // Execute the Python script.
-  //
-  MITK_INFO << msg << "Execute script ...";
-  auto result = PyObject_Call(pyFunc, dummyArgs, kwargs);
-  MITK_INFO << msg << "Done.";
-
-  // Check for errors.
-  PyErr_Print();
-
-  // If the convert results files was not successful then
-  // then display error messages and the script log file.
-  //
-  // Search for the Python logger ERROR or WARNING messages in the 
-  // returned result to determine if the script failed.
-  //
-  if (result) {
-      auto uResult = PyUnicode_FromObject(result);
-      auto sResult = std::string(PyUnicode_AsUTF8(uResult));
-
-      if (sResult.find("ERROR") != std::string::npos) {
-          MITK_WARN << "Converting reduced-order results files has failed.";
-          MITK_WARN << "Returned message: " << QString(sResult.c_str()); 
-          QMessageBox mb(nullptr);
-          //mb.setWindowTitle(sv4guiROMSimulationView::MsgTitle);
-          mb.setText("Converting reduced-order results files has failed.");
-          mb.setIcon(QMessageBox::Critical);
-          mb.setDetailedText(QString(sResult.c_str()));
-          mb.setDefaultButton(QMessageBox::Ok);
-          mb.exec();
-      } else {
-          QString rmsg = "Reduced-order solver files have been successfully converted.\n";
-          MITK_INFO << msg << rmsg;
-          //QMessageBox::information(NULL, sv4guiROMSimulationView::MsgTitle, rmsg);
-      }
-  }
-
-  return SV_OK;
 }
 
 //--------------

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.h
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.h
@@ -46,6 +46,8 @@
 #include <vtkPolyData.h>
 #include <vtkSmartPointer.h>
 
+#include <QString>
+
 //-------------------------------------------
 // sv4guiROMSimulationPythonConvertParamNames
 //-------------------------------------------
@@ -81,6 +83,8 @@ class sv4guiROMSimulationPythonConvertParamNames
 // sv4guiROMSimulationPythonConvert
 //----------------------------------
 //
+class sv4guiConvertWorkerROM;
+
 class sv4guiROMSimulationPythonConvert
 {
   public:
@@ -96,10 +100,9 @@ class sv4guiROMSimulationPythonConvert
 
     std::string AddArgument(const std::string& arg, const std::string& value, bool last=false);
     bool AddParameter(const std::string& name, const std::string& value = "");
-    bool ConvertResults(const std::string outputDirectory);
     bool ConvertResultsProcess(const std::string outputDirectory);
+    bool ConvertResultsWorker(sv4guiConvertWorkerROM* convertWorker, const std::string outputDirectory);
     std::string StartCommand();
-
 };
 
 #endif 

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.h
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationPythonConvert.h
@@ -97,6 +97,7 @@ class sv4guiROMSimulationPythonConvert
     std::string AddArgument(const std::string& arg, const std::string& value, bool last=false);
     bool AddParameter(const std::string& name, const std::string& value = "");
     bool ConvertResults(const std::string outputDirectory);
+    bool ConvertResultsProcess(const std::string outputDirectory);
     std::string StartCommand();
 
 };

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationView.h
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.romsimulation/sv4gui_ROMSimulationView.h
@@ -49,6 +49,7 @@
 #include "sv4gui_ROMSimulationLinesContainer.h"
 #include "sv4gui_ROMSimulationLinesMapper.h"
 #include "sv4gui_ROMSimulationPython.h"
+#include "sv4gui_ConvertWorkerROM.h"
 
 #include "sv4gui_CapSelectionWidget.h"
 #include "sv4gui_ProcessHandlerROM.h"
@@ -296,6 +297,11 @@ public slots:
 
     void SetupInternalSolverPaths();
 
+    // Slots executed by ConvertWorkerROM signals. 
+    void ShowConvertWorkerMessage(const bool errorMsg, const QString& msg);
+    void ConvertWorkerError(const QString& msg);
+    void ConvertWorkerFinished();
+
 public:
 
     virtual void CreateQtPartControl(QWidget *parent) override;
@@ -476,6 +482,7 @@ private:
 
     QString GetExportResultsDir();
 
+    sv4guiConvertWorkerROM* m_ConvertWorker;
 };
 
 #endif // SV4GUI_ROMSIMULATIONVIEW_H

--- a/Python/site-packages/sv_rom_extract_results/extract_results.py
+++ b/Python/site-packages/sv_rom_extract_results/extract_results.py
@@ -100,7 +100,7 @@ class Args(object):
     RESULTS_DIRECTORY  = "results_directory"
     SEGMENTS = "segments"
     SELECT_SEGMENTS = "select_segments"
-    SOLVER_FILE = "solver_file_name"
+    SOLVER_FILE_NAME = "solver_file_name"
     TIME_RANGE = "time_range"
     WALLS_MESH_FILE = "walls_mesh_file"
     
@@ -134,7 +134,7 @@ def parse_args():
     parser.add_argument(cmd(Args.NODE_SPHERE_RADIUS), 
       help="Radius of node sphere markers.")
 
-    parser.add_argument(cmd(Args.OUTLET_SEGMENTS), action='store_true',
+    parser.add_argument(cmd(Args.OUTLET_SEGMENTS), default=False, action='store_true', 
       help="If given then read all outlet segment data.")
 
     parser.add_argument(cmd(Args.OUTPUT_DIRECTORY), 
@@ -158,17 +158,20 @@ def parse_args():
     parser.add_argument(cmd(Args.SELECT_SEGMENTS), action='store_true',
       help="Select segments to convert.")
 
-    parser.add_argument(cmd(Args.SOLVER_FILE), required=True,
+    parser.add_argument(cmd(Args.SOLVER_FILE_NAME), required=True,
       help="Solver .in file.")
 
-    parser.add_argument(cmd(Args.SURFACE_MESH_FILE),
-      help="Surface mesh file.")
+    #parser.add_argument(cmd(Args.SURFACE_MESH_FILE),
+    #  help="Surface mesh file.")
 
     parser.add_argument(cmd(Args.TIME_RANGE), 
       help="Time range to save and plot.")
 
     parser.add_argument(cmd(Args.VOLUME_MESH_FILE),
       help="Volume mesh file.")
+
+    parser.add_argument(cmd(Args.WALLS_MESH_FILE),
+      help="Combined walls mesh file.")
 
     return parser.parse_args(), parser.print_help
 
@@ -215,7 +218,7 @@ def set_parameters(**kwargs):
         params.output_format = kwargs.get(Args.OUTPUT_FORMAT)
     logger.info("Output format: %s" % params.output_format)
 
-    params.solver_file_name = kwargs.get(Args.SOLVER_FILE)
+    params.solver_file_name = kwargs.get(Args.SOLVER_FILE_NAME)
     logger.info("Solver file name: %s" % params.solver_file_name)
 
     if kwargs.get(Args.DATA_NAMES):
@@ -250,7 +253,8 @@ def set_parameters(**kwargs):
         logger.info("Segments: %s" % ','.join(params.segment_names))
 
     if kwargs.get(Args.TIME_RANGE):
-        params.time_range = [float(s) for s in kwargs.get(Args.TIME_RANGE).split(",")]
+        time_range = kwargs.get(Args.TIME_RANGE).replace('"', '')
+        params.time_range = [float(s) for s in time_range.split(",")]
         logger.info("Time range: %s" % ','.join(map(str,params.time_range)))
 
     if kwargs.get(Args.CENTERLINES_FILE):
@@ -349,8 +353,12 @@ if __name__ == '__main__':
     """
     Execute the convert 0D or 1D solver results form the command line.
     """
+    args = sys.argv
+
     init_logging()
+
     args, print_help = parse_args()
+
     params = set_parameters(**vars(args))
 
     if params == None:

--- a/Python/site-packages/sv_rom_extract_results/extract_results.py
+++ b/Python/site-packages/sv_rom_extract_results/extract_results.py
@@ -294,8 +294,8 @@ def run(**kwargs):
     params = set_parameters(**kwargs)
 
     if not params:
-        logger.error("Error in parameters.")
-        return result
+        msg = "Error in parameters."
+        raise Exception(msg)
 
     if params.model_order == 1:
         ## Read in the solver file.
@@ -318,7 +318,7 @@ def run(**kwargs):
     post.process()
 
     logger.info("Converted results finished.")
-    result = "Successfully converted results" 
+    result = "Successfully converted results\n" 
     return result 
 
 def run_from_c(*args, **kwargs):
@@ -328,7 +328,14 @@ def run_from_c(*args, **kwargs):
     The '*args' argument contains the directory to write the log file.
     """
     output_dir = args[0]
+
+    # Inialize logging.
     init_logging(output_dir)
+    log_file_name = os.path.join(output_dir, get_log_file_name())
+    open(log_file_name, 'w').close()
+
+    # Convert results.
+    #
     msg = "Status: OK\n"
 
     try:
@@ -337,13 +344,11 @@ def run_from_c(*args, **kwargs):
     except Exception as e:
         logger.error(str(e))
         msg = "Status: Error\n"
-        msg += "Error: " + str(e) + "\n"
+        msg += str(e) + "\n"
 
     ## Attach log file to returned result.
     #
     msg += "Log:\n"
-    log_file_name = os.path.join(output_dir, get_log_file_name())
-
     with open(log_file_name, 'r') as file:
         msg += file.read()
 

--- a/Python/site-packages/sv_rom_extract_results/manage.py
+++ b/Python/site-packages/sv_rom_extract_results/manage.py
@@ -44,11 +44,12 @@ def get_log_file_name():
 def init_logging(outputDir="./"):
     import logging
     logger = logging.getLogger(get_logger_name())
-    logger.setLevel(logging.INFO)
-    console_handler = logging.StreamHandler()
     formatter = logging.Formatter('[%(name)s] %(levelname)s - %(message)s')
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
+    if not logger.hasHandlers():
+        logger.setLevel(logging.INFO)
+        console_handler = logging.StreamHandler()
+        console_handler.setFormatter(formatter)
+        logger.addHandler(console_handler)
 
     logFile = os.path.join(outputDir, get_log_file_name())
     file_handler = logging.FileHandler(logFile, mode="w")

--- a/Python/site-packages/sv_rom_extract_results/solver.py
+++ b/Python/site-packages/sv_rom_extract_results/solver.py
@@ -70,7 +70,7 @@ except ImportError:
 try:
     from matplotlib import pyplot as plt
 except ImportError:
-    print("matplotlib is not installed")
+    print("[sv_rom_extract_results] matplotlib is not installed")
 
 class Solver(object):
     """


### PR DESCRIPTION
These updates implement the execution of the Python `sv_rom_extract_results/extract_results.py` script to convert ROM simulation results. `QThreads` are used to execute the script so it doesn't freeze the SV GUI. 

@osmsc These changes need to be tested on Windows, some not very clear documentation about using `QThreads`.