### PR TITLE
Fix reading model type from .mdl file.

### DIFF
--- a/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelIO.cxx
+++ b/Code/Source/sv4gui/Modules/Model/Common/sv4gui_ModelIO.cxx
@@ -102,10 +102,8 @@ sv4guiModel::Pointer sv4guiModelIO::CreateGroupFromFile(std::string fileName)
     }
 
     sv4guiModel::Pointer model = sv4guiModel::New();
-    //std::string modelType="";
-    //modelElement->QueryStringAttribute("type", &modelType);
-    const char* modelType="";
-    //modelElement->QueryStringAttribute("type", &modelType);
+    const char* modelType = "";
+    modelElement->QueryStringAttribute("type", &modelType);
     model->SetType(modelType);
 
     int timestep=-1;


### PR DESCRIPTION
The model type was not being read from the .mdl file and was therefore being set to ''. The option panels are only displayed when the model type is PolyData.
