### PR TITLE
Modify MultiPhysics Tool to not use 'Create Job' button

### DIFF
--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.multiphysics/sv4gui_MultiPhysicsJobCreate.cxx
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.multiphysics/sv4gui_MultiPhysicsJobCreate.cxx
@@ -29,6 +29,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+// Implements the popup shown when selecting the 'Create MultiPhysics job' from the SV Data Manager GUI.
+//
 #include "sv4gui_MultiPhysicsJobCreate.h"
 #include "ui_sv4gui_MultiPhysicsJobCreate.h"
 
@@ -72,15 +74,26 @@ sv4guiMultiPhysicsJobCreate::~sv4guiMultiPhysicsJobCreate()
     delete ui;
 }
 
+//-----------
+// Activated
+//-----------
+//
 void sv4guiMultiPhysicsJobCreate::Activated()
 {
+    #define n_debug_Activated
+    #ifdef debug_Activated
+    std::string dmsg("[sv4guiMultiPhysicsJobCreate::Activated] ");
+    std::cout << dmsg << "========== Activated ===========" << std::endl;
+    #endif
+
     ui->comboBox->clear();
 
     m_ModelFolderNode=nullptr;
     m_SimulationFolderNode=nullptr;
 
-    if(m_SelecteNode.IsNull())
+    if(m_SelecteNode.IsNull()) {
         return;
+    }
 
     mitk::DataNode::Pointer selectedNode=m_SelecteNode;
 
@@ -126,8 +139,18 @@ void sv4guiMultiPhysicsJobCreate::SetFocus( )
     ui->comboBox->setFocus();
 }
 
+//-----------
+// CreateJob
+//-----------
+//
 void sv4guiMultiPhysicsJobCreate::CreateJob()
 {
+    #define n_debug_CreateJob
+    #ifdef debug_CreateJob
+    std::string dmsg("[sv4guiMultiPhysicsJobCreate::CreateJob] ");
+    std::cout << dmsg << "========== CreateJob ===========" << std::endl;
+    #endif
+
     QString selectedModelName=ui->comboBox->currentText();
     if(selectedModelName=="")
     {
@@ -180,12 +203,16 @@ void sv4guiMultiPhysicsJobCreate::CreateJob()
     mitk::DataNode::Pointer jobNode = mitk::DataNode::New();
     jobNode->SetData(mitkJob);
     jobNode->SetName(jobName);
+    #ifdef debug_CreateJob
+    std::cout << dmsg << "Create jobNode: " << jobName << std::endl;
+    #endif
 
 //    m_DataStorage->Add(jobNode,m_SimulationFolderNode);
     mitk::OperationEvent::IncCurrObjectEventId();
 
     bool undoEnabled=true;
     sv4guiDataNodeOperation* doOp = new sv4guiDataNodeOperation(sv4guiDataNodeOperation::OpADDDATANODE,m_DataStorage,jobNode,m_SimulationFolderNode);
+
     if(undoEnabled)
     {
         sv4guiDataNodeOperation* undoOp = new sv4guiDataNodeOperation(sv4guiDataNodeOperation::OpREMOVEDATANODE,m_DataStorage,jobNode,m_SimulationFolderNode);

--- a/Code/Source/sv4gui/Plugins/org.sv.gui.qt.multiphysics/sv4gui_MultiPhysicsView.ui
+++ b/Code/Source/sv4gui/Plugins/org.sv.gui.qt.multiphysics/sv4gui_MultiPhysicsView.ui
@@ -25,54 +25,6 @@
      <property name="spacing">
       <number>5</number>
      </property>
-     <item row="2" column="2">
-      <widget class="QPushButton" name="btnLoadJob">
-       <property name="text">
-        <string>Load Job</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_25">
-       <property name="text">
-        <string>Job Status:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QPushButton" name="btnSave">
-       <property name="text">
-        <string>Save Job</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="btnNewJob">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>New Job</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="labelJobName">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QPushButton" name="loadMeshButton">
-       <property name="text">
-        <string>Load Mesh</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="label_14">
        <property name="sizePolicy">
@@ -83,6 +35,20 @@
        </property>
        <property name="text">
         <string>Job Name:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_25">
+       <property name="text">
+        <string>Job Status:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="labelJobName">
+       <property name="text">
+        <string/>
        </property>
       </widget>
      </item>
@@ -106,7 +72,7 @@
            <x>0</x>
            <y>0</y>
            <width>449</width>
-           <height>557</height>
+           <height>564</height>
           </rect>
          </property>
          <attribute name="label">
@@ -276,7 +242,7 @@
            <x>0</x>
            <y>0</y>
            <width>449</width>
-           <height>593</height>
+           <height>625</height>
           </rect>
          </property>
          <attribute name="label">
@@ -2399,7 +2365,7 @@
            <x>0</x>
            <y>0</y>
            <width>449</width>
-           <height>557</height>
+           <height>564</height>
           </rect>
          </property>
          <attribute name="label">


### PR DESCRIPTION
I've removed the `Create Job` and other buttons at the top of the panel.

The MultiPhysics Tool  now works like other SV Tools.
