### PR TITLE
Removing Pv from Outflow BC type CORONARY

### DIFF
--- a/Python/site-packages/sv_rom_simulation/io_0d.py
+++ b/Python/site-packages/sv_rom_simulation/io_0d.py
@@ -131,7 +131,6 @@ def write_0d_solver_file(mesh, params, model):
                 outflow['bc_values'][name] = val
             outflow['bc_values']['t'] = bc_val['time']
             outflow['bc_values']['Pim'] = bc_val['pressure']
-            outflow['bc_values']['Pv'] = 0.0
         inp['boundary_conditions'] += [outflow]
 
     # write to file


### PR DESCRIPTION
As per issue #1136, Pv was removed from io_0d.py to ensure consistency with the solver’s expected parameter definitions (P_v instead of Pv, as per test file steadyFlow_R_coronary.json).
