### PR TITLE
Fix improper indexing in a float[3] array.

### DIFF
--- a/Code/Source/sv3/ITKSegmentation/sv3_ITKUtils.cxx
+++ b/Code/Source/sv3/ITKSegmentation/sv3_ITKUtils.cxx
@@ -231,8 +231,7 @@ void vtkGenerateCircle(double radius,double center[3],
 
 	vtkSmartPointer<vtkTransform> translation =
 			vtkSmartPointer<vtkTransform>::New();
-	translation->Translate(center[0], center[1], center[3]);
-
+	translation->Translate(center);
 
 	vtkSmartPointer<vtkTransformPolyDataFilter> transformFilter =
 			vtkSmartPointer<vtkTransformPolyDataFilter>::New();


### PR DESCRIPTION
An improper indexing of a float[3] array was causing random -Infs to occur in the level set initial front (https://github.com/SimVascular/SimVascular/issues/1140).

