### PR TITLE
Add check for just one branch ID.

### DIFF
--- a/Python/site-packages/sv_rom_extract_results/post.py
+++ b/Python/site-packages/sv_rom_extract_results/post.py
@@ -267,7 +267,8 @@ class Post(object):
 
         # all branch ids in centerline
         ids_cent = np.unique(arrays_cent['BranchId']).tolist()
-        ids_cent.remove(-1)
+        if len(ids_cent) > 1:
+            ids_cent.remove(-1)
 
         # loop all result fields
         for f in self.params.data_names:


### PR DESCRIPTION
A 1D simulation for a cylinder was failing.
